### PR TITLE
[REFACTOR] dto 유효성 검증용 핸들러 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-web-services'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
     runtimeOnly 'com.h2database:h2'
@@ -37,6 +38,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     //SMTP
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '3.0.5'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/bookjourneybackend/domain/test/TestController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/test/TestController.java
@@ -1,14 +1,14 @@
 package com.example.bookjourneybackend.domain.test;
 
-import com.example.bookjourneybackend.global.common.exception.GlobalException;
-import com.example.bookjourneybackend.global.common.response.BaseResponse;
-import com.example.bookjourneybackend.global.common.response.status.BaseExceptionResponseStatus;
-import org.apache.coyote.BadRequestException;
+import com.example.bookjourneybackend.global.exception.GlobalException;
+import com.example.bookjourneybackend.global.response.BaseResponse;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.example.bookjourneybackend.global.common.response.status.BaseExceptionResponseStatus.*;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.*;
 
 @RestController
 public class TestController {
@@ -31,4 +31,8 @@ public class TestController {
         throw new GlobalException(CANNOT_FOUND_USER);
     }
 
+    @PostMapping("/dtoValidated")
+    public BaseResponse<String> triggerValidatedException(@RequestBody @Valid final TestRequest testRequest) {
+        return BaseResponse.ok("");
+    }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/test/TestRequest.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/test/TestRequest.java
@@ -1,0 +1,34 @@
+package com.example.bookjourneybackend.domain.test;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TestRequest {
+
+    @NotBlank(message = "이메일 입력은 필수입니다. 최소 6자 이상입니다.")
+    @Size(min = 6)
+    private String email;
+
+    @NotNull(message = "비밀번호 입력은 필수입니다.")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9]).{8,16}$", message = "비밀번호는 영어와 숫자를 포함해서 8자 이상 16자 이내로 입력해주세요.")
+    private String password;
+
+    //todo 닉네임 4~12 한글 제한
+    @NotNull(message = "닉네임 입력은 필수입니다.")
+    @Size(min=4, message = "닉네임은 최소 4자 이상입니다.")
+    private String name;
+
+    @Builder
+    public TestRequest(String email, String password, String name) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/global/config/RedisConfig.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/RedisConfig.java
@@ -1,0 +1,4 @@
+package com.example.bookjourneybackend.global.config;
+
+public class RedisConfig {
+}

--- a/src/main/java/com/example/bookjourneybackend/global/exception/GlobalException.java
+++ b/src/main/java/com/example/bookjourneybackend/global/exception/GlobalException.java
@@ -1,6 +1,6 @@
-package com.example.bookjourneybackend.global.common.exception;
+package com.example.bookjourneybackend.global.exception;
 
-import com.example.bookjourneybackend.global.common.response.status.ResponseStatus;
+import com.example.bookjourneybackend.global.response.status.ResponseStatus;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/example/bookjourneybackend/global/handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/example/bookjourneybackend/global/handler/GlobalControllerAdvice.java
@@ -1,11 +1,14 @@
-package com.example.bookjourneybackend.global.common.exception_handler;
+package com.example.bookjourneybackend.global.handler;
 
-import com.example.bookjourneybackend.global.common.exception.GlobalException;
-import com.example.bookjourneybackend.global.common.response.BaseErrorResponse;
+import com.example.bookjourneybackend.global.exception.GlobalException;
+import com.example.bookjourneybackend.global.response.BaseErrorResponse;
+import com.example.bookjourneybackend.global.response.BaseResponse;
 import jakarta.annotation.Priority;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.coyote.BadRequestException;
 import org.hibernate.TypeMismatchException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -41,6 +44,20 @@ public class GlobalControllerAdvice {
     public BaseErrorResponse handleRestApiException(GlobalException e) {
         log.error("[handle_RestApiException]", e);
         return new BaseErrorResponse(e.getExceptionStatus(), e.getMessage());
+    }
+
+    //dto 유효성 검증 예외처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public BaseResponse<Void> handleValidationException(MethodArgumentNotValidException ex) {
+        // 첫 번째 유효성 검사 실패 메시지만 가져오기
+        String errorMessage = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(error -> error.getDefaultMessage())
+                .orElse("Validation failed");
+
+        return BaseResponse.of(HttpStatus.BAD_REQUEST, errorMessage, null);
     }
 
 }

--- a/src/main/java/com/example/bookjourneybackend/global/response/BaseErrorResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/BaseErrorResponse.java
@@ -1,6 +1,6 @@
-package com.example.bookjourneybackend.global.common.response;
+package com.example.bookjourneybackend.global.response;
 
-import com.example.bookjourneybackend.global.common.response.status.ResponseStatus;
+import com.example.bookjourneybackend.global.response.status.ResponseStatus;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/example/bookjourneybackend/global/response/BaseResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/BaseResponse.java
@@ -1,6 +1,6 @@
-package com.example.bookjourneybackend.global.common.response;
+package com.example.bookjourneybackend.global.response;
 
-import com.example.bookjourneybackend.global.common.response.status.ResponseStatus;
+import com.example.bookjourneybackend.global.response.status.ResponseStatus;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -1,4 +1,4 @@
-package com.example.bookjourneybackend.global.common.response.status;
+package com.example.bookjourneybackend.global.response.status;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/ResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/ResponseStatus.java
@@ -1,4 +1,4 @@
-package com.example.bookjourneybackend.global.common.response.status;
+package com.example.bookjourneybackend.global.response.status;
 
 import org.springframework.http.HttpStatus;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- closed #22  

## 📝작업 내용

> ControllerAdvice에 dto 유효성 검증 핸들러를 추가했습니다.

테스트는 다음과 같이 진행했습니다. @Valid 사용시 다음과 같이 사용하시면 됩니다.
<img width="857" alt="스크린샷 2025-01-18 오전 3 30 31" src="https://github.com/user-attachments/assets/b2f3a5b6-34e8-4afe-b00e-30d355ee9c06" />

<img width="989" alt="스크린샷 2025-01-18 오전 3 31 35" src="https://github.com/user-attachments/assets/4efce7d1-08c3-4203-8ae8-a751d9a33828" />


### 스크린샷 
> postman으로 실행한 결과입니다. BaseResponse 프로토콜을 따르기 때문에 code(400 고정), status, message로 나오고 message에 에러 메시지가 뜨게됩니다.
<img width="647" alt="스크린샷 2025-01-18 오전 3 31 50" src="https://github.com/user-attachments/assets/0e31395b-c5a1-4e3b-8d95-7fbd33bd5e75" />

## 💬리뷰 요구사항(선택)

- 추가적으로 config 파일의 패키지 정리도 진행하였습니다.
- Valid 관련 어노테이션들을 정리해둔 링크 참고하시면 좋겠습니다!
-> [쟈미의 devlog](https://jyami.tistory.com/55)
