### PR TITLE
[FEAT] 책 검색 책 목록 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     //Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    //Jackson (JSON 파싱용)
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/example/bookjourneybackend/domain/book/controller/BookController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/controller/BookController.java
@@ -1,4 +1,23 @@
 package com.example.bookjourneybackend.domain.book.controller;
 
+import com.example.bookjourneybackend.domain.book.dto.request.GetBookListRequest;
+import com.example.bookjourneybackend.domain.book.dto.response.GetBookListResponse;
+import com.example.bookjourneybackend.domain.book.service.BookService;
+import com.example.bookjourneybackend.global.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/books")
+@RequiredArgsConstructor
 public class BookController {
+    private final BookService bookService;
+
+    @GetMapping("/search")
+    public BaseResponse<GetBookListResponse> viewBookList(final GetBookListRequest getBookListRequest) {
+        return BaseResponse.ok(bookService.searchBook(getBookListRequest));
+    }
+
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/book/domain/Book.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/domain/Book.java
@@ -30,8 +30,8 @@ public class Book extends BaseEntity {
 
     private LocalDateTime publishedDate;
 
-    @Column(length = 13)
-    private Long isbnCode;
+    @Column(nullable = false, length = 13)
+    private String isbnCode;
 
     private Integer pageCount;
 
@@ -44,9 +44,7 @@ public class Book extends BaseEntity {
     private String authorName;
 
     @Builder
-    public Book(Long bookId, Genre genre, String bookTitle, String publisher,
-                LocalDateTime publishedDate, Long isbnCode, Integer pageCount, String description,
-                Integer roomCount, String authorName) {
+    public Book(Long bookId, Genre genre, String bookTitle, String publisher, LocalDateTime publishedDate, String isbnCode, Integer pageCount, String description, Integer roomCount, String authorName) {
         this.bookId = bookId;
         this.genre = genre;
         this.bookTitle = bookTitle;

--- a/src/main/java/com/example/bookjourneybackend/domain/book/domain/GenreType.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/domain/GenreType.java
@@ -1,31 +1,37 @@
 package com.example.bookjourneybackend.domain.book.domain;
 
+import com.example.bookjourneybackend.global.exception.GlobalException;
 import lombok.Getter;
+
+import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.*;
 
 @Getter
 public enum GenreType {
 
-    NOVEL_POETRY_DRAMA("소설/시/희곡"),
-    SOCIAL_SCIENCE("사회과학"),
-    BUSINESS_MANAGEMENT("경제경영"),
-    HISTORY("역사"),
-    ART_POP_CULTURE("예술/대중문화"),
-    RELIGION_ASTROLOGY("종교/역학"),
-    HUMANITIES("인문학"),
-    ESSAY("에세이"),
-    GOOD_PARENTING("좋은부모"),
-    COMICS("만화"),
-    SELF_DEVELOPMENT("자기계발"),
-    HEALTH_HOBBY("건강/취미"),
-    SCIENCE("과학"),
-    TEENAGERS("청소년"),
-    CHILDREN_INFANTS("어린이/유아"),
-    ETC("기타");
+    NOVEL_POETRY_DRAMA("소설/시/희곡", 1),
+    SOCIAL_SCIENCE("사회과학", 798),
+    BUSINESS_MANAGEMENT("경제경영", 170),
+    HISTORY("역사", 74),
+    ART_POP_CULTURE("예술/대중문화", 517),
+    RELIGION_ASTROLOGY("종교/역학", 1237),
+    HUMANITIES("인문학", 656),
+    ESSAY("에세이", 55889),
+    GOOD_PARENTING("좋은부모", 2030),
+    COMICS("만화", 2551),
+    SELF_DEVELOPMENT("자기계발", 336),
+    HEALTH_HOBBY("건강/취미/레저", 55890),
+    SCIENCE("과학", 987),
+    TEENAGERS("청소년", 1137),
+    CHILDREN("어린이", 1108),
+    INFANTS("유아", 13789);
+//    ETC("기타");
 
-    private String genreType;
+    private final String genreType;
+    private final int categoryId;
 
-    GenreType(String genreType) {
+    GenreType(String genreType, int categoryId) {
         this.genreType = genreType;
+        this.categoryId = categoryId;
     }
 
     public static GenreType getGenreType(String genreType) {
@@ -34,6 +40,6 @@ public enum GenreType {
                 return genre;
             }
         }
-        return null;
+        throw new GlobalException(INVALID_GENRE);
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/book/domain/repository/BookRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/domain/repository/BookRepository.java
@@ -1,4 +1,9 @@
 package com.example.bookjourneybackend.domain.book.domain.repository;
 
-public interface BookRepository {
+import com.example.bookjourneybackend.domain.book.domain.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BookRepository extends JpaRepository<Book, Long> {
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/book/dto/request/GetBookListRequest.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/dto/request/GetBookListRequest.java
@@ -1,0 +1,32 @@
+package com.example.bookjourneybackend.domain.book.dto.request;
+
+import com.example.bookjourneybackend.domain.book.domain.GenreType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GetBookListRequest {
+
+    private String searchTerm;
+
+    private GenreType genreType;
+
+    private String queryType;
+
+    private int page;
+
+    @Builder
+    public GetBookListRequest(String searchTerm, String genre, String queryType, int page) {
+        this.searchTerm = searchTerm;
+        this.genreType = GenreType.getGenreType(genre);
+        this.queryType = queryType;
+        this.page = page;
+    }
+
+    public GetBookListRequest IncreasePage() {
+        page++;
+        return this;
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/book/dto/response/BookInfo.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/dto/response/BookInfo.java
@@ -1,0 +1,18 @@
+package com.example.bookjourneybackend.domain.book.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public class BookInfo {
+    private String bookTitle;
+
+    private String authorName;
+
+    private String isbnCode;
+
+    private String imageUrl;
+
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/book/dto/response/GetBookListResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/dto/response/GetBookListResponse.java
@@ -1,0 +1,24 @@
+package com.example.bookjourneybackend.domain.book.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class GetBookListResponse {
+    private List<BookInfo> bookList;
+
+    public GetBookListResponse(List<BookInfo> bookList) {
+        this.bookList = bookList;
+    }
+
+    public void addBookInfo(BookInfo bookInfo) {
+        this.bookList.add(bookInfo);
+    }
+
+    public static GetBookListResponse of(List<BookInfo> bookList) {
+        return new GetBookListResponse(bookList);
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BookCacheService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BookCacheService.java
@@ -1,0 +1,101 @@
+package com.example.bookjourneybackend.domain.book.service;
+
+import com.example.bookjourneybackend.domain.book.dto.request.GetBookListRequest;
+import com.example.bookjourneybackend.global.exception.GlobalException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.ALADIN_API_ERROR;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BookCacheService {
+
+    @Value("${aladin.key}")
+    private String TTBKey;
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    public static final String ALADIN_BASEL_URL = "http://www.aladin.co.kr/ttb/api";
+    private final String ALADIN_ITEM_SEARCH_PATH = "/ItemSearch.aspx";   //상품 검색 API (책 검색용)
+    private final String ALADIN_ITEM_LOOKUP_PATH = "/ItemLookUp.aspx";
+    private final String ALADIN_ITEM_LIST_PATH = "/ItemList.aspx";   //상품 리스트 API (베스트셀러 조회용)
+
+    private final int MAX_RESULTS = 10; //최대 책 검색 결과 개수
+    private final String OUTPUT = "js"; // 응답 포맷 (xml 또는 json)
+
+    //Big : 큰 크기 : 너비 200px
+    //MidBig : 중간 큰 크기 : 너비 150px
+    //Mid(기본값) : 중간 크기 : 너비 85px
+    //Small : 작은 크기 : 너비 75px
+    //Mini : 매우 작은 크기 : 너비 65px
+    //None : 없음
+    private final String COVER_SIZE = "MidBig";
+
+    //Ex) books:searchTerm:해리포터(인코딩 안된상태로 들어감):genreType:NOVEL_POETRY_DRAMA:queryType:Title:page:1
+    @Cacheable(
+            cacheNames = "getBooks",
+            key = "'books:searchTerm:' + #p0?.searchTerm + " +
+                    "':genreType:' + #p0?.genreType + " +
+                    "':queryType:' + #p0?.queryType + " +
+                    "':page:' + #p0?.page",
+            cacheManager = "bookCacheManager"
+    )
+    public String getCurrentPage(GetBookListRequest getBookListRequest) {
+        log.info("[getCurrentPage Caching] 검색어: {}, 장르명: {}, 검색종류: {}, 페이지수: {}",
+                getBookListRequest.getSearchTerm(), getBookListRequest.getGenreType(), getBookListRequest.getQueryType(), getBookListRequest.getPage());
+
+        String requestUrl = buildApiUrl(getBookListRequest);
+        String currentResponse;
+
+        try {
+            currentResponse = restTemplate.getForEntity(requestUrl, String.class).getBody();
+            checkValidatedResponse(currentResponse);
+            log.info("알라딘 API 응답 Body: {}", currentResponse);
+
+        } catch (RestClientException e) {
+            throw new GlobalException(ALADIN_API_ERROR);
+        }
+
+
+        return currentResponse;
+    }
+
+    //알라딘 API로부터 받은 Response에 에러가 없는지 확인
+    private void checkValidatedResponse(String currentResponse) {
+        try {
+            JsonNode root = objectMapper.readTree(currentResponse);
+            if (root.has("errorCode")) {
+                throw new GlobalException(ALADIN_API_ERROR);
+            }
+        } catch (JsonProcessingException e) {
+//            throw new RuntimeException(e);
+        }
+    }
+
+    private String buildApiUrl(GetBookListRequest request) {
+        return String.format(
+                ALADIN_BASEL_URL + ALADIN_ITEM_SEARCH_PATH +
+                        "?ttbkey=%s&Query=%s&QueryType=%s&start=%d&MaxResults=%d&output=%s&CategoryId=%d&Cover=%s",
+                TTBKey,
+                request.getSearchTerm(),
+                request.getQueryType(),
+                request.getPage(),
+                MAX_RESULTS,
+                OUTPUT,
+                request.getGenreType().getCategoryId(),
+                COVER_SIZE
+        );
+    }
+
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
@@ -1,4 +1,103 @@
 package com.example.bookjourneybackend.domain.book.service;
 
+import com.example.bookjourneybackend.domain.book.domain.repository.BookRepository;
+import com.example.bookjourneybackend.domain.book.dto.request.GetBookListRequest;
+import com.example.bookjourneybackend.domain.book.dto.response.BookInfo;
+import com.example.bookjourneybackend.domain.book.dto.response.GetBookListResponse;
+import com.example.bookjourneybackend.global.exception.GlobalException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.*;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class BookService {
+
+    private final BookRepository bookRepository;
+    private final ObjectMapper objectMapper;
+    private final BookCacheService bookCacheService;
+
+    /**
+     * 1. Redis에 있는지 확인하고 있으면 Redis에 value로 반환
+     * 2. RestTemplate을 이용해 동기적으로 현재 페이지 불러와서 Redis에 저장 후 응답 전송
+     * 3. RestTemplate을 이용해 비동기적으로 다음 페이지를 불러와서 Redis에 저장
+     * Thread.start() 대신 CompletableFuture를 이용한 이유 : Thread Pool을 사용해 자원을 효율적으로 관리
+     * @param getBookListRequest
+     * @return
+     */
+    //todo Thread Pool Monitoring 로그 출력
+    public GetBookListResponse searchBook(GetBookListRequest getBookListRequest) {
+        log.info("------------------------[BookService.searchBook]------------------------");
+
+        // 현재 페이지 데이터 가져오기
+        String currentResponse = bookCacheService.getCurrentPage(getBookListRequest);
+
+        // 비동기적으로 다음 페이지 캐싱
+        CompletableFuture.runAsync(() -> {
+            bookCacheService.getCurrentPage(getBookListRequest.IncreasePage());
+            log.info("Next page caching completed for request page: {}", getBookListRequest.IncreasePage().getPage());
+        });
+
+        List<BookInfo> bookList = new ArrayList<>();
+
+        //응답 JSON 데이터 파싱
+        bookList = parseBookListFromResponse(currentResponse, bookList);
+
+
+        log.info("Caching completed for current page.");
+        log.info("currentResponse: {}", currentResponse);
+        return GetBookListResponse.of(bookList);
+    }
+
+    //todo 책 상세보기용 캐싱 전략 짜기 (key -> isbn코드)
+    private List<BookInfo> parseBookListFromResponse(String currentResponse, List<BookInfo> bookList) {
+        try{
+            //JSON 형식 오류 허용 -> "Unrecognized character escape ''' (code 39)" 에러 해결용
+            objectMapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
+            objectMapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+//            currentResponse = currentResponse.replace("'", "\"");
+
+            JsonNode root = objectMapper.readTree(currentResponse);
+            JsonNode items = root.get("item");
+
+            if (items != null && items.isArray()) {
+                bookList = new ArrayList<>();
+                for (JsonNode item : items) {
+                    String title = item.get("title").asText();
+                    String author = item.get("author").asText();
+
+                    //isbn 13자리가 비어있는 경우 10자리 사용
+                    String isbn = item.has("isbn13") && !item.get("isbn13").asText().isEmpty()
+                            ? item.get("isbn13").asText()
+                            : item.get("isbn").asText();
+                    String cover = item.get("cover").asText();
+
+//                    String link = item.get("link").asText();
+//                    String description = item.get("description").asText();
+//                    String categoryName = item.get("categoryName").asText();
+//                    String publisher = item.get("publisher").asText();
+
+                    bookList.add(new BookInfo(title, author, isbn, cover));
+                }
+            }
+        } catch (JsonProcessingException e) {
+            log.info("Json 파싱 에러 메시지: {}", e.getMessage());
+            throw new GlobalException(ALADIN_API_PARSING_ERROR);
+        }
+        return bookList;
+    }
+
 }

--- a/src/main/java/com/example/bookjourneybackend/global/config/AppConfig.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.example.bookjourneybackend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/RedisCacheConfig.java
@@ -1,0 +1,42 @@
+package com.example.bookjourneybackend.global.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+    @Bean
+    public CacheManager bookCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
+                .defaultCacheConfig()
+                //Redis에 Key를 저장할 때 String으로 직렬화(변환)해서 저장
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new StringRedisSerializer()))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new Jackson2JsonRedisSerializer<Object>(Object.class)
+                        )
+                )
+                .entryTtl(Duration.ofMinutes(1L));
+
+        return RedisCacheManager
+                .RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+}
+

--- a/src/main/java/com/example/bookjourneybackend/global/config/RedisConfig.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/RedisConfig.java
@@ -1,14 +1,23 @@
 package com.example.bookjourneybackend.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
 
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
@@ -18,4 +27,11 @@ public class RedisConfig {
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         return redisTemplate;
     }
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        // Lettuce라는 라이브러리를 활용해 Redis 연결을 관리하는 객체를 생성하고
+        // Redis 서버에 대한 정보(host, port)를 설정한다.
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+
 }

--- a/src/main/java/com/example/bookjourneybackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
             "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html",
             "/auth/login","/users/signup","/users/emails/verification-requests","/users/emails/verifications",
             "/users/nickname","/h2-console/**"
+            , "/books/search"   //개발을 위해 일시적으로 허용..
     };
 
 

--- a/src/main/java/com/example/bookjourneybackend/global/config/WebConfig.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/WebConfig.java
@@ -1,0 +1,24 @@
+package com.example.bookjourneybackend.global.config;
+
+import com.example.bookjourneybackend.global.resolver.GetBookListRequestArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final GetBookListRequestArgumentResolver getBookListRequestArgumentResolver;
+
+    public WebConfig(GetBookListRequestArgumentResolver getBookListRequestArgumentResolver) {
+        this.getBookListRequestArgumentResolver = getBookListRequestArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        // Argument Resolver 등록
+        resolvers.add(getBookListRequestArgumentResolver);
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/global/resolver/GetBookListRequestArgumentResolver.java
+++ b/src/main/java/com/example/bookjourneybackend/global/resolver/GetBookListRequestArgumentResolver.java
@@ -1,0 +1,59 @@
+package com.example.bookjourneybackend.global.resolver;
+
+import com.example.bookjourneybackend.domain.book.dto.request.GetBookListRequest;
+import com.example.bookjourneybackend.global.exception.GlobalException;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.*;
+
+@Component
+public class GetBookListRequestArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(GetBookListRequest.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        String searchTerm = webRequest.getParameter("searchTerm");
+        String genre = webRequest.getParameter("genre");
+        String queryType = webRequest.getParameter("queryType");
+
+        String pageParam = webRequest.getParameter("page");
+        int page = (pageParam == null || pageParam.trim().isEmpty()) ? 0 : Integer.parseInt(pageParam);
+
+        validateRequest(searchTerm, page, queryType);
+
+        return GetBookListRequest.builder()
+                .searchTerm(searchTerm)
+                .genre(genre)
+                .queryType(queryType)
+                .page(page)
+                .build();
+
+    }
+
+    //dto 유효성 검증
+    private void validateRequest(String searchTerm, int page, String queryType) {
+        // 검색어가 비어있는지 검사
+        if (searchTerm == null || searchTerm.isBlank()) {
+            throw new GlobalException(EMPTY_SEARCH_TERM);
+        }
+        // 페이지가 1보다 작은지 검사
+        if (!(page >= 1)) {
+            throw new GlobalException(INVALID_PAGE);
+        }
+        // queryType 유효성 검사
+        if (queryType == null || queryType.isBlank() ||
+                !(queryType.equals("Title") || queryType.equals("Author"))) {
+            throw new GlobalException(INVALID_QUERY_TYPE);
+        }
+    }
+
+}

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -21,12 +21,22 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     /**
      * 5000 : user 관련
      */
-    CANNOT_FOUND_USER(5000,BAD_REQUEST, "해당하는 유저가 없습니다."),
+    CANNOT_FOUND_USER(5000,BAD_REQUEST, "유저를 찾을 수 없습니다."),
 
     /**
      * 6000 : book 관련
      */
     CANNOT_FOUND_BOOK(6000, BAD_REQUEST, "책을 찾을 수 없습니다."),
+
+    INVALID_GENRE(6001, BAD_REQUEST, "알맞은 장르를 찾을 수 없습니다"),
+    EMPTY_SEARCH_TERM(6001, BAD_REQUEST, "검색어는 비워둘 수 없습니다."),
+    INVALID_PAGE(6001, BAD_REQUEST, "페이지 번호는 1 이상입니다."),
+    INVALID_QUERY_TYPE(6001, BAD_REQUEST, "알맞은 검색 종류가 아닙니다."),
+
+    ALADIN_API_ERROR(6002, BAD_REQUEST, "알라딘 API 호출에 실패하였습니다."),
+    ALADIN_API_PARSING_ERROR(6003, BAD_REQUEST, "알라딘 API 응답 파싱에 실패하였습니다."),
+
+
 
     /**
      * 7000 : auth 관련

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -179,6 +179,9 @@ jwt:
   access-token-expiration: 3600000 #1시간
   refresh-token-expiration: 604800000 #7일
 
+aladin:
+  key: ${ALADIN_API_KEY}
+
 #logging:
 #  level:
 #    root: DEBUG


### PR DESCRIPTION
## #️⃣연관된 이슈

- closed #25 

## 📝작업 내용

1. 책 찾기 API 요청이 오면 알라딘 API를 사용해 책 목록을 조회합니다.
2. 조회한 책 목록을 Redis에 캐싱하고 응답을 보냅니다.
3. 응답을 보낸 후 비동기적으로 다음 페이지에 대한 알라딘 API 요청을 보내어 Redis에 캐싱해둡니다.
4. Redis에 있는 요청이 오면 Redis에서 value값을 조회하여 조회 성능을 올립니다.

### 스크린샷 
첫 조회 시 (3.58s)
<img width="847" alt="스크린샷 2025-01-20 오후 5 14 49" src="https://github.com/user-attachments/assets/138e937f-ff34-434c-9944-458c158ed8a4" />

다음 페이지 혹은 현재 페이지 재조회시 (13ms) 
<img width="847" alt="스크린샷 2025-01-20 오후 5 15 16" src="https://github.com/user-attachments/assets/db02f03b-fdf0-494b-8637-50b56166eed1" />

## 💬리뷰 요구사항
- isbn 13자리가 없는 경우가 존재해서 없는 경우에는 10자리를 사용하도록 했습니다. (10자리는 문자열이라 Book Entity 필드를 수정했습니다.)
- 모든 예외처리는 API 명세서에 작성해뒀으니 확인 부탁드립니다.
