### PR TITLE
[FEAT] 책 정보 상세보기 구현

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/book/controller/BookController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/controller/BookController.java
@@ -5,6 +5,7 @@ import com.example.bookjourneybackend.domain.book.dto.response.GetBookInfoRespon
 import com.example.bookjourneybackend.domain.book.dto.response.GetBookListResponse;
 import com.example.bookjourneybackend.domain.book.service.BookService;
 import com.example.bookjourneybackend.global.response.BaseResponse;
+import com.example.bookjourneybackend.global.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class BookController {
     private final BookService bookService;
+    private final JwtUtil jwtUtil;
 
     @GetMapping("/search")
     public BaseResponse<GetBookListResponse> viewBookList(final GetBookListRequest getBookListRequest) {
@@ -22,8 +24,10 @@ public class BookController {
     }
 
     @GetMapping("/info/{isbn}")
-    public BaseResponse<GetBookInfoResponse> viewBookInfo(@PathVariable("isbn") final String isbn) {
-        return BaseResponse.ok(bookService.showBookInfo(isbn));
+    public BaseResponse<GetBookInfoResponse> viewBookInfo(@PathVariable("isbn") final String isbn,
+                                                          @RequestHeader("Authorization") String authorization) {
+        Long userId = jwtUtil.extractIdFromHeader(authorization);
+        return BaseResponse.ok(bookService.showBookInfo(isbn, userId));
     }
 
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/book/controller/BookController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/controller/BookController.java
@@ -21,7 +21,7 @@ public class BookController {
         return BaseResponse.ok(bookService.searchBook(getBookListRequest));
     }
 
-    @GetMapping("/info")
+    @GetMapping("/info/{isbn}")
     public BaseResponse<GetBookInfoResponse> viewBookInfo(@PathVariable("isbn") final String isbn) {
         return BaseResponse.ok(bookService.showBookInfo(isbn));
     }

--- a/src/main/java/com/example/bookjourneybackend/domain/book/controller/BookController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/controller/BookController.java
@@ -1,6 +1,7 @@
 package com.example.bookjourneybackend.domain.book.controller;
 
 import com.example.bookjourneybackend.domain.book.dto.request.GetBookListRequest;
+import com.example.bookjourneybackend.domain.book.dto.response.GetBookInfoResponse;
 import com.example.bookjourneybackend.domain.book.dto.response.GetBookListResponse;
 import com.example.bookjourneybackend.domain.book.service.BookService;
 import com.example.bookjourneybackend.global.response.BaseResponse;
@@ -18,6 +19,11 @@ public class BookController {
     @GetMapping("/search")
     public BaseResponse<GetBookListResponse> viewBookList(final GetBookListRequest getBookListRequest) {
         return BaseResponse.ok(bookService.searchBook(getBookListRequest));
+    }
+
+    @GetMapping("/info")
+    public BaseResponse<GetBookInfoResponse> viewBookInfo(@PathVariable("isbn") final String isbn) {
+        return BaseResponse.ok(bookService.showBookInfo(isbn));
     }
 
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/book/domain/Book.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/domain/Book.java
@@ -37,7 +37,7 @@ public class Book extends BaseEntity {
     private LocalDateTime publishedDate;
 
     @Column(nullable = false, length = 13)
-    private String isbnCode;
+    private String isbn;
 
     private Integer pageCount;
 
@@ -54,13 +54,13 @@ public class Book extends BaseEntity {
     private List<Favorite> favorites = new ArrayList<>();
 
     @Builder
-    public Book(Long bookId, Genre genre, String bookTitle, String publisher, LocalDateTime publishedDate, String isbnCode, Integer pageCount, String description, Integer roomCount, String authorName) {
+    public Book(Long bookId, Genre genre, String bookTitle, String publisher, LocalDateTime publishedDate, String isbn, Integer pageCount, String description, Integer roomCount, String authorName) {
         this.bookId = bookId;
         this.genre = genre;
         this.bookTitle = bookTitle;
         this.publisher = publisher;
         this.publishedDate = publishedDate;
-        this.isbnCode = isbnCode;
+        this.isbn = isbn;
         this.pageCount = pageCount;
         this.description = description;
         this.roomCount = roomCount;

--- a/src/main/java/com/example/bookjourneybackend/domain/book/domain/Book.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/domain/Book.java
@@ -1,16 +1,22 @@
 package com.example.bookjourneybackend.domain.book.domain;
 
+import com.example.bookjourneybackend.domain.favorite.domain.Favorite;
 import com.example.bookjourneybackend.global.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
+@Builder
 @Entity
 @Table(name = "books")
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor
 public class Book extends BaseEntity {
 
@@ -43,6 +49,10 @@ public class Book extends BaseEntity {
     @Column(nullable = false, length = 50)
     private String authorName;
 
+    @OneToMany(mappedBy = "book")
+    @Builder.Default
+    private List<Favorite> favorites = new ArrayList<>();
+
     @Builder
     public Book(Long bookId, Genre genre, String bookTitle, String publisher, LocalDateTime publishedDate, String isbnCode, Integer pageCount, String description, Integer roomCount, String authorName) {
         this.bookId = bookId;
@@ -55,5 +65,9 @@ public class Book extends BaseEntity {
         this.description = description;
         this.roomCount = roomCount;
         this.authorName = authorName;
+    }
+
+    public void addFavorite(Favorite favorite) {
+        this.favorites.add(favorite);
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/book/domain/repository/BookRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/domain/repository/BookRepository.java
@@ -4,6 +4,10 @@ import com.example.bookjourneybackend.domain.book.domain.Book;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface BookRepository extends JpaRepository<Book, Long> {
+
+    Optional<Book> findByIsbnCode(String isbn);
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/book/domain/repository/BookRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/domain/repository/BookRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 @Repository
 public interface BookRepository extends JpaRepository<Book, Long> {
 
-    Optional<Book> findByIsbnCode(String isbn);
+    Optional<Book> findByIsbn(String isbn);
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/book/dto/response/BookInfo.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/dto/response/BookInfo.java
@@ -2,7 +2,6 @@ package com.example.bookjourneybackend.domain.book.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
@@ -11,7 +10,7 @@ public class BookInfo {     //책 목록에서 나오는 책 정보들
 
     private String authorName;
 
-    private String isbnCode;
+    private String isbn;
 
     private String imageUrl;
 

--- a/src/main/java/com/example/bookjourneybackend/domain/book/dto/response/BookInfo.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/dto/response/BookInfo.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-public class BookInfo {
+public class BookInfo {     //책 목록에서 나오는 책 정보들
     private String bookTitle;
 
     private String authorName;

--- a/src/main/java/com/example/bookjourneybackend/domain/book/dto/response/GetBookInfoResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/dto/response/GetBookInfoResponse.java
@@ -1,6 +1,5 @@
 package com.example.bookjourneybackend.domain.book.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,22 +24,22 @@ public class GetBookInfoResponse {
 
     private String publishedDate;
 
-    private String isbnCode;
+    private String isbn;
 
     private String description;
 
-    public GetBookInfoResponse(String genre, String imageUrl, String bookTitle, String authorName, String publisher, String publishedDate, String isbnCode, String description) {
+    public GetBookInfoResponse(String genre, String imageUrl, String bookTitle, String authorName, String publisher, String publishedDate, String isbn, String description) {
         this.genre = genre;
         this.imageUrl = imageUrl;
         this.bookTitle = bookTitle;
         this.authorName = authorName;
         this.publisher = publisher;
         this.publishedDate = publishedDate;
-        this.isbnCode = isbnCode;
+        this.isbn = isbn;
         this.description = description;
     }
 
-    public static GetBookInfoResponse of(String genre, String imageUrl, String bookTitle, String authorName, boolean favorite, String publisher, String publishedDate, String isbnCode, String description) {
-        return new GetBookInfoResponse(genre, imageUrl, bookTitle, authorName, favorite, publisher, publishedDate, isbnCode, description);
+    public static GetBookInfoResponse of(String genre, String imageUrl, String bookTitle, String authorName, boolean favorite, String publisher, String publishedDate, String isbn, String description) {
+        return new GetBookInfoResponse(genre, imageUrl, bookTitle, authorName, favorite, publisher, publishedDate, isbn, description);
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/book/dto/response/GetBookInfoResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/dto/response/GetBookInfoResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @NoArgsConstructor
@@ -17,6 +18,7 @@ public class GetBookInfoResponse {
 
     private String authorName;
 
+    @Setter
     private boolean favorite;
 
     private String publisher;

--- a/src/main/java/com/example/bookjourneybackend/domain/book/dto/response/GetBookInfoResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/dto/response/GetBookInfoResponse.java
@@ -1,0 +1,44 @@
+package com.example.bookjourneybackend.domain.book.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetBookInfoResponse {
+    private String genre;
+
+    private String imageUrl;
+
+    private String bookTitle;
+
+    private String authorName;
+
+    private boolean favorite;
+
+    private String publisher;
+
+    private String publishedDate;
+
+    private String isbnCode;
+
+    private String description;
+
+    public GetBookInfoResponse(String genre, String imageUrl, String bookTitle, String authorName, String publisher, String publishedDate, String isbnCode, String description) {
+        this.genre = genre;
+        this.imageUrl = imageUrl;
+        this.bookTitle = bookTitle;
+        this.authorName = authorName;
+        this.publisher = publisher;
+        this.publishedDate = publishedDate;
+        this.isbnCode = isbnCode;
+        this.description = description;
+    }
+
+    public static GetBookInfoResponse of(String genre, String imageUrl, String bookTitle, String authorName, boolean favorite, String publisher, String publishedDate, String isbnCode, String description) {
+        return new GetBookInfoResponse(genre, imageUrl, bookTitle, authorName, favorite, publisher, publishedDate, isbnCode, description);
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BookCacheService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BookCacheService.java
@@ -3,6 +3,7 @@ package com.example.bookjourneybackend.domain.book.service;
 import com.example.bookjourneybackend.domain.book.dto.request.GetBookListRequest;
 import com.example.bookjourneybackend.domain.book.dto.response.GetBookInfoResponse;
 import com.example.bookjourneybackend.global.exception.GlobalException;
+import com.example.bookjourneybackend.global.util.AladinApiUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,27 +22,8 @@ import static com.example.bookjourneybackend.global.response.status.BaseExceptio
 @RequiredArgsConstructor
 public class BookCacheService {
 
-    @Value("${aladin.key}")
-    private String TTBKey;
-
     private final RestTemplate restTemplate;
-    private final ObjectMapper objectMapper;
-
-    public static final String ALADIN_BASEL_URL = "http://www.aladin.co.kr/ttb/api";
-    private final String ALADIN_ITEM_SEARCH_PATH = "/ItemSearch.aspx";   //상품 검색 API (책 검색용)
-    private final String ALADIN_ITEM_LOOKUP_PATH = "/ItemLookUp.aspx";
-    private final String ALADIN_ITEM_LIST_PATH = "/ItemList.aspx";   //상품 리스트 API (베스트셀러 조회용)
-
-    private final int MAX_RESULTS = 10; //최대 책 검색 결과 개수
-    private final String OUTPUT = "js"; // 응답 포맷 (xml 또는 json)
-
-    //Big : 큰 크기 : 너비 200px
-    //MidBig : 중간 큰 크기 : 너비 150px
-    //Mid(기본값) : 중간 크기 : 너비 85px
-    //Small : 작은 크기 : 너비 75px
-    //Mini : 매우 작은 크기 : 너비 65px
-    //None : 없음
-    private final String COVER_SIZE = "MidBig";
+    private final AladinApiUtil aladinApiUtil;
 
     //Ex) books:searchTerm:해리포터(인코딩 안된상태로 들어감):genreType:NOVEL_POETRY_DRAMA:queryType:Title:page:1
     @Cacheable(
@@ -56,12 +38,12 @@ public class BookCacheService {
         log.info("[getCurrentPage Caching] 검색어: {}, 장르명: {}, 검색종류: {}, 페이지수: {}",
                 getBookListRequest.getSearchTerm(), getBookListRequest.getGenreType(), getBookListRequest.getQueryType(), getBookListRequest.getPage());
 
-        String requestUrl = buildApiUrl(getBookListRequest);
+        String requestUrl = aladinApiUtil.buildApiUrl(getBookListRequest);
         String currentResponse;
 
         try {
             currentResponse = restTemplate.getForEntity(requestUrl, String.class).getBody();
-            checkValidatedResponse(currentResponse);
+            aladinApiUtil.checkValidatedResponse(currentResponse);
             log.info("알라딘 API 응답 Body: {}", currentResponse);
 
         } catch (RestClientException e) {
@@ -72,41 +54,22 @@ public class BookCacheService {
         return currentResponse;
     }
 
-
-    //알라딘 API로부터 받은 Response에 에러가 없는지 확인
-    private void checkValidatedResponse(String currentResponse) {
-        try {
-            JsonNode root = objectMapper.readTree(currentResponse);
-            if (root.has("errorCode")) {
-                throw new GlobalException(ALADIN_API_ERROR);
-            }
-        } catch (JsonProcessingException e) {
-//            throw new RuntimeException(e);
-        }
-    }
-
-    private String buildApiUrl(GetBookListRequest request) {
-        return String.format(
-                ALADIN_BASEL_URL + ALADIN_ITEM_SEARCH_PATH +
-                        "?ttbkey=%s&Query=%s&QueryType=%s&start=%d&MaxResults=%d&output=%s&CategoryId=%d&Cover=%s",
-                TTBKey,
-                request.getSearchTerm(),
-                request.getQueryType(),
-                request.getPage(),
-                MAX_RESULTS,
-                OUTPUT,
-                request.getGenreType().getCategoryId(),
-                COVER_SIZE
-        );
-    }
-
     @Cacheable(
             cacheNames = "getBookInfo",
             key = "'books:isbn:' + #p2",
             cacheManager = "bookInfoCacheManager"
     )
     public GetBookInfoResponse cachingBookInfo(String title, String author, String isbn, String cover, String description, String categoryName, String publisher, String publishedDate) {
-
         return new GetBookInfoResponse(categoryName, cover, title, author, publisher, publishedDate, isbn, description);
+    }
+
+    @Cacheable(
+            cacheNames = "getBookInfo",
+            key = "'books:isbn:' + #p0",
+            cacheManager = "bookInfoCacheManager"
+    )
+    public GetBookInfoResponse checkBookInfo(String isbn) {
+
+        return null;
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BookCacheService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BookCacheService.java
@@ -4,18 +4,19 @@ import com.example.bookjourneybackend.domain.book.dto.request.GetBookListRequest
 import com.example.bookjourneybackend.domain.book.dto.response.GetBookInfoResponse;
 import com.example.bookjourneybackend.global.exception.GlobalException;
 import com.example.bookjourneybackend.global.util.AladinApiUtil;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.ALADIN_API_ERROR;
+import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.ALADIN_API_PARSING_ERROR;
 
 @Slf4j
 @Service
@@ -24,6 +25,7 @@ public class BookCacheService {
 
     private final RestTemplate restTemplate;
     private final AladinApiUtil aladinApiUtil;
+    private final ObjectMapper objectMapper;
 
     //Ex) books:searchTerm:해리포터(인코딩 안된상태로 들어감):genreType:NOVEL_POETRY_DRAMA:queryType:Title:page:1
     @Cacheable(
@@ -38,7 +40,7 @@ public class BookCacheService {
         log.info("[getCurrentPage Caching] 검색어: {}, 장르명: {}, 검색종류: {}, 페이지수: {}",
                 getBookListRequest.getSearchTerm(), getBookListRequest.getGenreType(), getBookListRequest.getQueryType(), getBookListRequest.getPage());
 
-        String requestUrl = aladinApiUtil.buildApiUrl(getBookListRequest);
+        String requestUrl = aladinApiUtil.buildSearchApiUrl(getBookListRequest);
         String currentResponse;
 
         try {
@@ -56,20 +58,66 @@ public class BookCacheService {
 
     @Cacheable(
             cacheNames = "getBookInfo",
-            key = "'books:isbn:' + #p2",
+            key = "'book:isbn:' + #p2",
             cacheManager = "bookInfoCacheManager"
     )
     public GetBookInfoResponse cachingBookInfo(String title, String author, String isbn, String cover, String description, String categoryName, String publisher, String publishedDate) {
-        return new GetBookInfoResponse(categoryName, cover, title, author, publisher, publishedDate, isbn, description);
+        return GetBookInfoResponse.of(categoryName, cover, title, author, false, publisher, publishedDate, isbn, description);
     }
 
     @Cacheable(
             cacheNames = "getBookInfo",
-            key = "'books:isbn:' + #p0",
+            key = "'book:isbn:' + #p0",
             cacheManager = "bookInfoCacheManager"
     )
     public GetBookInfoResponse checkBookInfo(String isbn) {
+        log.info("[checkBookInfo Caching] isbn: {}",
+                isbn);
 
-        return null;
+        String requestUrl = aladinApiUtil.buildLookUpApiUrl(isbn);
+        String currentResponse;
+        GetBookInfoResponse getBookInfoResponse = null;
+
+        try {
+            currentResponse = restTemplate.getForEntity(requestUrl, String.class).getBody();
+            aladinApiUtil.checkValidatedResponse(currentResponse);
+            log.info("알라딘 API 응답 Body: {}", currentResponse);
+
+            //JSON 형식 오류 허용 -> "Unrecognized character escape ''' (code 39)" 에러 해결용
+            objectMapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
+            objectMapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+//            currentResponse = currentResponse.replace("'", "\"");
+
+            JsonNode root = objectMapper.readTree(currentResponse);
+            JsonNode items = root.get("item");
+
+            if (items != null && items.isArray()) {
+                for (JsonNode item : items) {
+                    String title = item.get("title").asText();
+                    String author = item.get("author").asText();
+
+                    //isbn 13자리가 비어있는 경우 10자리 사용
+//                    String isbn = item.has("isbn13") && !item.get("isbn13").asText().isEmpty()
+//                            ? item.get("isbn13").asText()
+//                            : item.get("isbn").asText();
+                    String cover = item.get("cover").asText();
+
+//                    String link = item.get("link").asText();
+                    String description = item.get("description").asText();
+                    String categoryName = item.get("categoryName").asText();
+                    String publisher = item.get("publisher").asText();
+                    String publishedDate = item.get("pubDate").asText();
+
+                    getBookInfoResponse = GetBookInfoResponse.of(categoryName, cover, title, author, false, publisher, publishedDate, isbn, description);
+                }
+            }
+        } catch (RestClientException e) {
+            throw new GlobalException(ALADIN_API_ERROR);
+        } catch (JsonProcessingException e) {
+            log.info("Json 파싱 에러 메시지: {}", e.getMessage());
+            throw new GlobalException(ALADIN_API_PARSING_ERROR);
+        }
+
+        return getBookInfoResponse;
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BookCacheService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BookCacheService.java
@@ -1,6 +1,7 @@
 package com.example.bookjourneybackend.domain.book.service;
 
 import com.example.bookjourneybackend.domain.book.dto.request.GetBookListRequest;
+import com.example.bookjourneybackend.domain.book.dto.response.GetBookInfoResponse;
 import com.example.bookjourneybackend.global.exception.GlobalException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -71,6 +72,7 @@ public class BookCacheService {
         return currentResponse;
     }
 
+
     //알라딘 API로부터 받은 Response에 에러가 없는지 확인
     private void checkValidatedResponse(String currentResponse) {
         try {
@@ -98,4 +100,13 @@ public class BookCacheService {
         );
     }
 
+    @Cacheable(
+            cacheNames = "getBookInfo",
+            key = "'books:isbn:' + #p2",
+            cacheManager = "bookInfoCacheManager"
+    )
+    public GetBookInfoResponse cachingBookInfo(String title, String author, String isbn, String cover, String description, String categoryName, String publisher, String publishedDate) {
+
+        return new GetBookInfoResponse(categoryName, cover, title, author, publisher, publishedDate, isbn, description);
+    }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
@@ -113,11 +113,12 @@ public class BookService {
 
         Optional<Book> findBook = bookRepository.findByIsbn(isbn);
 
-        if (findBook.isPresent()) {     //레포지토리에 책이 존재하면..
-            if (favoriteRepository.existsActiveFavoriteByUserIdAndBook(userId, findBook.get())) {
-                getBookInfoResponse.setFavorite(true);   //즐겨찾기 추가
-            }
-        }
+        //레포지토리에 책이 존재하면..
+        findBook.ifPresent(book -> {
+            boolean isFavorite = favoriteRepository.existsActiveFavoriteByUserIdAndBook(userId, book);
+            getBookInfoResponse.setFavorite(isFavorite);
+        });
+
         bookCacheService.checkBookInfo(isbn);
 
         return getBookInfoResponse;

--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
@@ -105,6 +105,6 @@ public class BookService {
     }
 
     public GetBookInfoResponse showBookInfo(String isbn) {
-        return null;
+        return bookCacheService.checkBookInfo(isbn);
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
@@ -55,7 +55,7 @@ public class BookService {
         List<BookInfo> bookList = new ArrayList<>();
 
         //응답 JSON 데이터 파싱
-        bookList = parseBookListFromResponse(currentResponse, bookList);
+        bookList = parseBookListFromResponse(currentResponse);
 
 
         log.info("Caching completed for current page.");
@@ -63,8 +63,8 @@ public class BookService {
         return GetBookListResponse.of(bookList);
     }
 
-    //todo 책 상세보기용 캐싱 전략 짜기 (key -> isbn코드)
-    private List<BookInfo> parseBookListFromResponse(String currentResponse, List<BookInfo> bookList) {
+    private List<BookInfo> parseBookListFromResponse(String currentResponse) {
+        List<BookInfo> bookList = new ArrayList<>();
         try{
             //JSON 형식 오류 허용 -> "Unrecognized character escape ''' (code 39)" 에러 해결용
             objectMapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
@@ -75,7 +75,6 @@ public class BookService {
             JsonNode items = root.get("item");
 
             if (items != null && items.isArray()) {
-                bookList = new ArrayList<>();
                 for (JsonNode item : items) {
                     String title = item.get("title").asText();
                     String author = item.get("author").asText();
@@ -105,6 +104,7 @@ public class BookService {
     }
 
     public GetBookInfoResponse showBookInfo(String isbn) {
+        log.info("------------------------[BookService.showBookInfo]------------------------");
         return bookCacheService.checkBookInfo(isbn);
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
@@ -97,7 +97,7 @@ public class BookService {
 
                     GetBookInfoResponse g = bookCacheService.cachingBookInfo(title, author, isbn, cover, description, categoryName, publisher, publishedDate);
 
-                    bookList.add(new BookInfo(g.getBookTitle(), g.getAuthorName(), g.getIsbnCode(), g.getImageUrl()));
+                    bookList.add(new BookInfo(g.getBookTitle(), g.getAuthorName(), g.getIsbn(), g.getImageUrl()));
                 }
             }
         } catch (JsonProcessingException e) {
@@ -111,7 +111,7 @@ public class BookService {
         log.info("------------------------[BookService.showBookInfo]------------------------");
         GetBookInfoResponse getBookInfoResponse = bookCacheService.checkBookInfo(isbn);
 
-        Optional<Book> findBook = bookRepository.findByIsbnCode(isbn);
+        Optional<Book> findBook = bookRepository.findByIsbn(isbn);
 
         if (findBook.isPresent()) {     //레포지토리에 책이 존재하면..
             if (favoriteRepository.existsActiveFavoriteByUserIdAndBook(userId, findBook.get())) {

--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
@@ -3,6 +3,7 @@ package com.example.bookjourneybackend.domain.book.service;
 import com.example.bookjourneybackend.domain.book.domain.repository.BookRepository;
 import com.example.bookjourneybackend.domain.book.dto.request.GetBookListRequest;
 import com.example.bookjourneybackend.domain.book.dto.response.BookInfo;
+import com.example.bookjourneybackend.domain.book.dto.response.GetBookInfoResponse;
 import com.example.bookjourneybackend.domain.book.dto.response.GetBookListResponse;
 import com.example.bookjourneybackend.global.exception.GlobalException;
 import com.fasterxml.jackson.core.JsonParser;
@@ -86,11 +87,14 @@ public class BookService {
                     String cover = item.get("cover").asText();
 
 //                    String link = item.get("link").asText();
-//                    String description = item.get("description").asText();
-//                    String categoryName = item.get("categoryName").asText();
-//                    String publisher = item.get("publisher").asText();
+                    String description = item.get("description").asText();
+                    String categoryName = item.get("categoryName").asText();
+                    String publisher = item.get("publisher").asText();
+                    String publishedDate = item.get("pubDate").asText();
 
-                    bookList.add(new BookInfo(title, author, isbn, cover));
+                    GetBookInfoResponse g = bookCacheService.cachingBookInfo(title, author, isbn, cover, description, categoryName, publisher, publishedDate);
+
+                    bookList.add(new BookInfo(g.getBookTitle(), g.getAuthorName(), g.getIsbnCode(), g.getImageUrl()));
                 }
             }
         } catch (JsonProcessingException e) {
@@ -100,4 +104,7 @@ public class BookService {
         return bookList;
     }
 
+    public GetBookInfoResponse showBookInfo(String isbn) {
+        return null;
+    }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/repository/FavoriteRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/repository/FavoriteRepository.java
@@ -1,4 +1,7 @@
 package com.example.bookjourneybackend.domain.favorite.domain.repository;
 
-public interface FavoriteRepository {
+import com.example.bookjourneybackend.domain.favorite.domain.Favorite;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/repository/FavoriteRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/repository/FavoriteRepository.java
@@ -1,7 +1,17 @@
 package com.example.bookjourneybackend.domain.favorite.domain.repository;
 
+import com.example.bookjourneybackend.domain.book.domain.Book;
 import com.example.bookjourneybackend.domain.favorite.domain.Favorite;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+    @Query("SELECT f FROM Favorite f WHERE f.user.userId = :userId AND f.book = :book AND f.status = 'active'")
+    Optional<Favorite> findActiveFavoriteByUserIdAndBook(@Param("userId") Long userId, @Param("book") Book book);
+
+    @Query("SELECT COUNT(f) > 0 FROM Favorite f WHERE f.user.userId = :userId AND f.book = :book AND f.status = 'active'")
+    boolean existsActiveFavoriteByUserIdAndBook(@Param("userId") Long userId, @Param("book") Book book);
 }

--- a/src/main/java/com/example/bookjourneybackend/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/RedisCacheConfig.java
@@ -4,6 +4,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -18,6 +19,7 @@ import java.time.Duration;
 @EnableCaching
 public class RedisCacheConfig {
     @Bean
+    @Primary
     public CacheManager bookCacheManager(RedisConnectionFactory redisConnectionFactory) {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
                 .defaultCacheConfig()
@@ -28,6 +30,28 @@ public class RedisCacheConfig {
                 .serializeValuesWith(
                         RedisSerializationContext.SerializationPair.fromSerializer(
                                 new Jackson2JsonRedisSerializer<Object>(Object.class)
+                        )
+                )
+                .entryTtl(Duration.ofMinutes(1L));
+
+        return RedisCacheManager
+                .RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+
+    @Bean
+    public CacheManager bookInfoCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
+                .defaultCacheConfig()
+                //Redis에 Key를 저장할 때 String으로 직렬화(변환)해서 저장
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new StringRedisSerializer()))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new GenericJackson2JsonRedisSerializer()
                         )
                 )
                 .entryTtl(Duration.ofMinutes(1L));

--- a/src/main/java/com/example/bookjourneybackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
             "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html",
             "/auth/login","/users/signup","/users/emails/verification-requests","/users/emails/verifications",
             "/users/nickname","/h2-console/**"
-            , "/books/search"   //개발을 위해 일시적으로 허용..
+            , "/books/**"   //개발을 위해 일시적으로 허용..
     };
 
 

--- a/src/main/java/com/example/bookjourneybackend/global/util/AladinApiUtil.java
+++ b/src/main/java/com/example/bookjourneybackend/global/util/AladinApiUtil.java
@@ -1,0 +1,68 @@
+package com.example.bookjourneybackend.global.util;
+
+import com.example.bookjourneybackend.domain.book.dto.request.GetBookListRequest;
+import com.example.bookjourneybackend.global.exception.GlobalException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.ALADIN_API_ERROR;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class AladinApiUtil {
+
+    @Value("${aladin.key}")
+    private String TTBKey;
+
+    public static final String ALADIN_BASEL_URL = "http://www.aladin.co.kr/ttb/api";
+    private final String ALADIN_ITEM_SEARCH_PATH = "/ItemSearch.aspx";   //상품 검색 API (책 검색용)
+    private final String ALADIN_ITEM_LOOKUP_PATH = "/ItemLookUp.aspx";
+    private final String ALADIN_ITEM_LIST_PATH = "/ItemList.aspx";   //상품 리스트 API (베스트셀러 조회용)
+
+    private final int MAX_RESULTS = 10; //최대 책 검색 결과 개수
+    private final String OUTPUT = "js"; // 응답 포맷 (xml 또는 json)
+
+    //Big : 큰 크기 : 너비 200px
+    //MidBig : 중간 큰 크기 : 너비 150px
+    //Mid(기본값) : 중간 크기 : 너비 85px
+    //Small : 작은 크기 : 너비 75px
+    //Mini : 매우 작은 크기 : 너비 65px
+    //None : 없음
+    private final String COVER_SIZE = "MidBig";
+
+    private final ObjectMapper objectMapper;
+
+
+    public String buildApiUrl(GetBookListRequest request) {
+        return String.format(
+                ALADIN_BASEL_URL + ALADIN_ITEM_SEARCH_PATH +
+                        "?ttbkey=%s&Query=%s&QueryType=%s&start=%d&MaxResults=%d&output=%s&CategoryId=%d&Cover=%s",
+                TTBKey,
+                request.getSearchTerm(),
+                request.getQueryType(),
+                request.getPage(),
+                MAX_RESULTS,
+                OUTPUT,
+                request.getGenreType().getCategoryId(),
+                COVER_SIZE
+        );
+    }
+
+    //알라딘 API로부터 받은 Response에 에러가 없는지 확인
+    public void checkValidatedResponse(String currentResponse) {
+        try {
+            JsonNode root = objectMapper.readTree(currentResponse);
+            if (root.has("errorCode")) {
+                throw new GlobalException(ALADIN_API_ERROR);
+            }
+        } catch (JsonProcessingException e) {
+//            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/global/util/AladinApiUtil.java
+++ b/src/main/java/com/example/bookjourneybackend/global/util/AladinApiUtil.java
@@ -39,7 +39,7 @@ public class AladinApiUtil {
     private final ObjectMapper objectMapper;
 
 
-    public String buildApiUrl(GetBookListRequest request) {
+    public String buildSearchApiUrl(GetBookListRequest request) {
         return String.format(
                 ALADIN_BASEL_URL + ALADIN_ITEM_SEARCH_PATH +
                         "?ttbkey=%s&Query=%s&QueryType=%s&start=%d&MaxResults=%d&output=%s&CategoryId=%d&Cover=%s",
@@ -50,6 +50,18 @@ public class AladinApiUtil {
                 MAX_RESULTS,
                 OUTPUT,
                 request.getGenreType().getCategoryId(),
+                COVER_SIZE
+        );
+    }
+
+    public String buildLookUpApiUrl(String isbn) {
+        return String.format(
+                ALADIN_BASEL_URL + ALADIN_ITEM_LOOKUP_PATH +
+                        "?ttbkey=%s&itemIdType=%s&ItemId=%s&output=%s&Cover=%s",
+                TTBKey,
+                isbn.length() == 13 ? "ISBN13" : "ISBN",
+                isbn,
+                OUTPUT,
                 COVER_SIZE
         );
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- closed #28 

## 📝작업 내용

> 전체회의에서 이야기한대로 이슈의 2번째 방법을 적용하였습니다. **_(책 상세보기에서는 책 전체 페이지를 보여주지 않고 기록을 시작하고 DB에 넣을때 API에 요청을 보내서 전체 페이지를 받아와서 DB에 넣어주기)_** 

**동작방식은 다음과 같습니다.**
1. 책 찾기에서 책 목록을 보여줄 때 모든 책에 대해서 Redis에 캐싱
2. 책 하나를 선택했을 때 isbn을 통해 Redis에서 조회 (존재하면 바로 응답, 존재하지 않으면 한번더 알라딘 api 요청해서 캐싱)
3. 조회가 완료되면 DB에서 즐겨찾기를 조회해서 userId와 book을 통해 즐겨찾기가 되어있는 책인지 확인

* 추가적으로 dto에서 즐겨찾기 필드는 이야기한 것처럼 isFavorite -> favorite으로 수정하였습니다!

### 스크린샷
즐겨찾기가 있을 경우
<img width="847" alt="스크린샷 2025-01-22 오전 3 36 52" src="https://github.com/user-attachments/assets/c7b0761a-75f3-4d33-8a2a-8196a0df8027" />


## 💬리뷰 요구사항

> api 구현이 최우선이라 생각해서 리팩토링은 간단하게 진행하였습니다. 추후에 더 리팩토링해보겠습니다 :)

**참조) 테스트할때 사용한 더미데이터입니다.**
```sql
INSERT INTO users (user_id, email, password, nickname, status, created_at, modified_at) VALUES (1, 'testuser1@example.com', 'asdf1234', 'testuser1', 'ACTIVE', NOW(), NOW()), (2, 'testuser2@example.com', 'asdf1234', 'testuser2', 'ACTIVE', NOW(), NOW()); 

INSERT INTO books (book_id, genre, book_title, publisher, published_date, isbn, page_count, description, room_count, author_name, created_at, modified_at, status, best_seller, image_url)
VALUES (
    1, 
     'BUSINESS_MANAGEMENT', 
    '[큰글자도서] 노랑무늬영원 - 2024 노벨문학상 수상작가, 개정판', 
    '문학과지성사', 
    '2024-11-10', 
    '9788932043333', 
    300, 
    '수십 번 계절이 바뀌는 동안 존재의 근원과 세계를 탐문하는 한강의 온 힘과 감각이 고통 속에 혹은 고통이 통과한 자취에 머무르는 사이...',
    0,
    '한강 지음', 
    NOW(),
    NOW(),
'active', 0, 'adjfkkljlk.jpg'
);

INSERT INTO favorites (favorite_id, user_id, book_id, created_at, modified_at)
VALUES (
    1, -- favorite_id (Auto Increment 가능)
    1, -- user_id
    1, -- book_id
    NOW(), -- created_at
    NOW()  -- updated_at
);
```