### PR TITLE
[REFACTOR] @LoginUserId 어노테이션 정의 및 적용

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/book/controller/BookController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/controller/BookController.java
@@ -4,6 +4,7 @@ import com.example.bookjourneybackend.domain.book.dto.request.GetBookListRequest
 import com.example.bookjourneybackend.domain.book.dto.response.GetBookInfoResponse;
 import com.example.bookjourneybackend.domain.book.dto.response.GetBookListResponse;
 import com.example.bookjourneybackend.domain.book.service.BookService;
+import com.example.bookjourneybackend.global.annotation.LoginUserId;
 import com.example.bookjourneybackend.global.response.BaseResponse;
 import com.example.bookjourneybackend.global.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -25,8 +26,7 @@ public class BookController {
 
     @GetMapping("/info/{isbn}")
     public BaseResponse<GetBookInfoResponse> viewBookInfo(@PathVariable("isbn") final String isbn,
-                                                          @RequestHeader("Authorization") String authorization) {
-        Long userId = jwtUtil.extractIdFromHeader(authorization);
+                                                          @LoginUserId Long userId) {
         return BaseResponse.ok(bookService.showBookInfo(isbn, userId));
     }
 

--- a/src/main/java/com/example/bookjourneybackend/domain/book/controller/BookController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/controller/BookController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class BookController {
     private final BookService bookService;
-    private final JwtUtil jwtUtil;
 
     @GetMapping("/search")
     public BaseResponse<GetBookListResponse> viewBookList(final GetBookListRequest getBookListRequest) {

--- a/src/main/java/com/example/bookjourneybackend/global/annotation/LoginUserId.java
+++ b/src/main/java/com/example/bookjourneybackend/global/annotation/LoginUserId.java
@@ -1,0 +1,11 @@
+package com.example.bookjourneybackend.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUserId {
+}

--- a/src/main/java/com/example/bookjourneybackend/global/config/WebConfig.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/WebConfig.java
@@ -1,6 +1,7 @@
 package com.example.bookjourneybackend.global.config;
 
 import com.example.bookjourneybackend.global.resolver.GetBookListRequestArgumentResolver;
+import com.example.bookjourneybackend.global.resolver.LoginUserResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -11,14 +12,17 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
 
     private final GetBookListRequestArgumentResolver getBookListRequestArgumentResolver;
+    private final LoginUserResolver loginUserResolver;
 
-    public WebConfig(GetBookListRequestArgumentResolver getBookListRequestArgumentResolver) {
+    public WebConfig(GetBookListRequestArgumentResolver getBookListRequestArgumentResolver, LoginUserResolver loginUserResolver) {
         this.getBookListRequestArgumentResolver = getBookListRequestArgumentResolver;
+        this.loginUserResolver = loginUserResolver;
     }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         // Argument Resolver 등록
         resolvers.add(getBookListRequestArgumentResolver);
+        resolvers.add(loginUserResolver);
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/global/resolver/LoginUserResolver.java
+++ b/src/main/java/com/example/bookjourneybackend/global/resolver/LoginUserResolver.java
@@ -15,6 +15,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 public class LoginUserResolver implements HandlerMethodArgumentResolver {
 
     private final JwtUtil jwtUtil;
+    private final String AUTHORIZATION_HEADER = "Authorization";
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -24,6 +25,6 @@ public class LoginUserResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
-        return jwtUtil.extractIdFromHeader(webRequest.getHeader("Authorization"));
+        return jwtUtil.extractIdFromHeader(webRequest.getHeader(AUTHORIZATION_HEADER));
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/global/resolver/LoginUserResolver.java
+++ b/src/main/java/com/example/bookjourneybackend/global/resolver/LoginUserResolver.java
@@ -1,0 +1,29 @@
+package com.example.bookjourneybackend.global.resolver;
+
+import com.example.bookjourneybackend.global.annotation.LoginUserId;
+import com.example.bookjourneybackend.global.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class LoginUserResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginUserId.class)
+                && parameter.getParameterType() == Long.class;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        return jwtUtil.extractIdFromHeader(webRequest.getHeader("Authorization"));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- closed #40 

## 📝작업 내용

> LoginUserId를 어노테이션을 정의하고 Resolver에서 jwt 토큰을 추출해 userId를 파라미터에 값으로 넣어주도록 하였습니다.

### 스크린샷 (선택)

`@LoginUserId` 를 적용한 코드입니다.
<img width="774" alt="스크린샷 2025-01-25 오전 2 28 02" src="https://github.com/user-attachments/assets/f2d175ad-76f4-4bfa-9b63-dd759997017f" />

userId를 잘 넣어주는 것을 api가 잘 작동되는 것으로 테스트해보았습니다.
<img width="847" alt="스크린샷 2025-01-25 오전 2 28 37" src="https://github.com/user-attachments/assets/901e7d11-7b77-457e-ad73-8106582fc1d6" />

더미데이터는 #34 에서의 더미데이터와 동일합니다!

## 💬리뷰 요구사항(선택)

