### PR TITLE
[REFACTOR]: 책 찾기 api의 쿼리 파라미터에서 genre가 null로 넘어올 경우 예외처리

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/book/dto/request/GetBookListRequest.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/dto/request/GetBookListRequest.java
@@ -20,7 +20,7 @@ public class GetBookListRequest {
     @Builder
     public GetBookListRequest(String searchTerm, String genre, String queryType, int page) {
         this.searchTerm = searchTerm;
-        this.genreType = GenreType.fromGenreType(genre);
+        this.genreType = genre == null? null: GenreType.fromGenreType(genre);
         this.queryType = queryType;
         this.page = page;
     }

--- a/src/main/java/com/example/bookjourneybackend/global/resolver/GetBookListRequestArgumentResolver.java
+++ b/src/main/java/com/example/bookjourneybackend/global/resolver/GetBookListRequestArgumentResolver.java
@@ -28,6 +28,8 @@ public class GetBookListRequestArgumentResolver implements HandlerMethodArgument
         String pageParam = webRequest.getParameter("page");
         int page = (pageParam == null || pageParam.trim().isEmpty()) ? 0 : Integer.parseInt(pageParam);
 
+        page++;
+
         validateRequest(searchTerm, page, queryType);
 
         return GetBookListRequest.builder()

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -30,7 +30,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
 
     INVALID_GENRE(6001, BAD_REQUEST, "알맞은 장르를 찾을 수 없습니다"),
     EMPTY_SEARCH_TERM(6001, BAD_REQUEST, "검색어는 비워둘 수 없습니다."),
-    INVALID_PAGE(6001, BAD_REQUEST, "페이지 번호는 1 이상입니다."),
+    INVALID_PAGE(6001, BAD_REQUEST, "페이지 번호는 0 이상입니다."),
     INVALID_QUERY_TYPE(6001, BAD_REQUEST, "알맞은 검색 종류가 아닙니다."),
 
     ALADIN_API_ERROR(6002, BAD_REQUEST, "알라딘 API 호출에 실패하였습니다."),

--- a/src/main/java/com/example/bookjourneybackend/global/util/AladinApiUtil.java
+++ b/src/main/java/com/example/bookjourneybackend/global/util/AladinApiUtil.java
@@ -59,7 +59,7 @@ public class AladinApiUtil {
                 request.getPage(),
                 MAX_RESULTS,
                 OUTPUT,
-                request.getGenreType().getCategoryId(),
+                request.getGenreType()==null? null: request.getGenreType().getCategoryId(),
                 COVER_SIZE
         );
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- closed #50 

## 📝작업 내용

> 책 찾기 api의 쿼리 파라미터에서 genre가 null로 넘어올 경우 예외처리를 추가했습니다.

### 스크린샷 
<img width="847" alt="스크린샷 2025-01-26 오후 7 18 53" src="https://github.com/user-attachments/assets/9c2e8d49-675d-42bc-8303-ea025bd9c00f" />

## 💬리뷰 요구사항(선택)

