### PR TITLE
[REFACTOR] 책 찾기 api 수정

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/book/dto/request/GetBookListRequest.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/dto/request/GetBookListRequest.java
@@ -18,9 +18,9 @@ public class GetBookListRequest {
     private int page;
 
     @Builder
-    public GetBookListRequest(String searchTerm, String genre, String queryType, int page) {
+    public GetBookListRequest(String searchTerm, GenreType genre, String queryType, int page) {
         this.searchTerm = searchTerm;
-        this.genreType = genre == null? null: GenreType.fromGenreType(genre);
+        this.genreType = genre;
         this.queryType = queryType;
         this.page = page;
     }

--- a/src/main/java/com/example/bookjourneybackend/global/resolver/GetBookListRequestArgumentResolver.java
+++ b/src/main/java/com/example/bookjourneybackend/global/resolver/GetBookListRequestArgumentResolver.java
@@ -1,6 +1,8 @@
 package com.example.bookjourneybackend.global.resolver;
 
+import com.example.bookjourneybackend.domain.book.domain.GenreType;
 import com.example.bookjourneybackend.domain.book.dto.request.GetBookListRequest;
+import com.example.bookjourneybackend.domain.room.domain.SearchType;
 import com.example.bookjourneybackend.global.exception.GlobalException;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -23,19 +25,19 @@ public class GetBookListRequestArgumentResolver implements HandlerMethodArgument
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         String searchTerm = webRequest.getParameter("searchTerm");
         String genre = webRequest.getParameter("genre");
-        String queryType = webRequest.getParameter("queryType");
+        String searchType = webRequest.getParameter("searchType");
 
         String pageParam = webRequest.getParameter("page");
         int page = (pageParam == null || pageParam.trim().isEmpty()) ? 0 : Integer.parseInt(pageParam);
 
         page++;
 
-        validateRequest(searchTerm, page, queryType);
+        validateRequest(searchTerm, page, searchType);
 
         return GetBookListRequest.builder()
                 .searchTerm(searchTerm)
-                .genre(genre)
-                .queryType(queryType)
+                .genre(genre == null? null: GenreType.fromGenreType(genre))
+                .queryType(SearchType.from(searchType).getQueryType())
                 .page(page)
                 .build();
 
@@ -52,9 +54,8 @@ public class GetBookListRequestArgumentResolver implements HandlerMethodArgument
             throw new GlobalException(INVALID_PAGE);
         }
         // queryType 유효성 검사
-        if (queryType == null || queryType.isBlank() ||
-                !(queryType.equals("Title") || queryType.equals("Author"))) {
-            throw new GlobalException(INVALID_QUERY_TYPE);
+        if (queryType == null || queryType.isBlank()) {
+            throw new GlobalException(INVALID_SEARCH_TYPE);
         }
     }
 

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -31,13 +31,11 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     INVALID_GENRE(6001, BAD_REQUEST, "알맞은 장르를 찾을 수 없습니다"),
     EMPTY_SEARCH_TERM(6001, BAD_REQUEST, "검색어는 비워둘 수 없습니다."),
     INVALID_PAGE(6001, BAD_REQUEST, "페이지 번호는 0 이상입니다."),
-    INVALID_QUERY_TYPE(6001, BAD_REQUEST, "알맞은 검색 종류가 아닙니다."),
 
     ALADIN_API_ERROR(6002, BAD_REQUEST, "알라딘 API 호출에 실패하였습니다."),
     ALADIN_API_PARSING_ERROR(6003, BAD_REQUEST, "알라딘 API 응답 파싱에 실패하였습니다."),
 
     CANNOT_FOUND_POPULAR_BOOK(6004, BAD_REQUEST, "읽기횟수가 가장 많은 책을 찾을 수 없습니다."),
-
 
 
     /**


### PR DESCRIPTION
## #️⃣연관된 이슈

- closed #59 

## 📝작업 내용

> 방 찾기 api에서 검색 종류에 대한 query parameter의 키를 searchType을 사용하기 때문에 책 찾기 api도 통일시켰습니다..
방 찾기 api에서 사용한 searchTerm의 ENUM을 활용하였습니다.

### 스크린샷 (선택)
<img width="847" alt="스크린샷 2025-01-26 오후 10 23 12" src="https://github.com/user-attachments/assets/1bd93c66-c935-49d8-a755-63855d669547" />

## 💬리뷰 요구사항(선택)

> 추가적으로 dto 쪽에서 하던 enum 매핑 로직을 resolver로 이동하여 dto의 기능을 줄였습니다!
