### PR TITLE
[FEAT] 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/auth/controller/AuthController.java
@@ -46,5 +46,13 @@ public class AuthController {
         return BaseResponse.ok(authService.tokenReissue(authAccessTokenReissueRequest,response,request));
     }
 
+    //로그아웃
+    @PostMapping("/logout")
+    public BaseResponse<Void> logout(@LoginUserId final Long userId){
+        log.info("[AuthController.logout]");
+        authService.logout(userId);
+        return BaseResponse.ok(null);
+    }
+
 
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/auth/service/AuthService.java
@@ -30,7 +30,7 @@ import static com.example.bookjourneybackend.global.response.status.BaseExceptio
 
 @Slf4j
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @RequiredArgsConstructor
 public class AuthService {
 
@@ -72,7 +72,7 @@ public class AuthService {
     }
 
 
-    @Transactional
+    @Transactional(readOnly = true)
     public PostAuthAccessTokenReissueResponse tokenReissue(PostAuthAccessTokenReissueRequest authAccessTokenReissueRequest,
                                                            HttpServletResponse response, HttpServletRequest request) {
         log.info("[AuthService.tokenReissue]");
@@ -104,5 +104,16 @@ public class AuthService {
 
     }
 
+    @Transactional
+    public void logout(Long userId) {
+        log.info("[AuthService.logout]");
 
+        //해당하는 유저 찾기
+        userRepository.findByUserIdAndStatus(userId, ACTIVE)
+                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
+
+        //리프레쉬 토큰 저장소에서 삭제
+        tokenService.invalidateToken(userId);
+
+    }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/domain/repository/UserRepository.java
@@ -3,15 +3,13 @@ package com.example.bookjourneybackend.domain.user.domain.repository;
 import com.example.bookjourneybackend.domain.user.domain.User;
 import com.example.bookjourneybackend.global.entity.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmailAndStatus(String email, EntityStatus status);
+    Optional<User> findByUserIdAndStatus(Long userId, EntityStatus status);
 
 
 }

--- a/src/main/java/com/example/bookjourneybackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
             "/users/signup","/users/emails/verification-requests","/users/emails/verifications",
             "/users/nickname","/h2-console/**"
 
-            , "/books/**", "/rooms/**",    //개발을 위해 일시적으로 허용..,
+//            , "/books/**", "/rooms/**",    //개발을 위해 일시적으로 허용..,
     };
 
 

--- a/src/main/java/com/example/bookjourneybackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
             "/users/signup","/users/emails/verification-requests","/users/emails/verifications",
             "/users/nickname","/h2-console/**"
 
-//            , "/books/**", "/rooms/**",    //개발을 위해 일시적으로 허용..,
+            , "/books/**", "/rooms/**",    //개발을 위해 일시적으로 허용..,
     };
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #54 

## 📝작업 내용

- 로그아웃 기능을 구현했습니다
- 로그아웃을 하면 해당 유저가 갖고있는 리프레쉬토큰이 저장소에서 삭제됩니다


### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/b80d5d58-c8c6-4ad4-85b8-9c9d90a56312)
로그아웃이 정상적으로 진행되는 것을 확인할수있습니다!
![image](https://github.com/user-attachments/assets/e9a5a772-29ef-4a5c-9d06-10db563a0fc7)
또한 레디스에서 로그아웃을 진행 했을 경우 토큰이 정상적으로 삭제되는 모습도 확인할수 있습니다!
![image](https://github.com/user-attachments/assets/cd331b09-ae64-47d0-9571-edccd87d58ae)
로그아웃을 진행하고나서 만료/삭제된 리프레쉬토큰으로 엑세스 토큰 재발급을 진행하면 토큰에대한 예외처리가 정상적으로 나오는것을 확인할수있습니다!

## 💬리뷰 요구사항(선택)
