### PR TITLE
[FEAT] 진행 중인 기록 조회 구현

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/book/domain/Book.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/domain/Book.java
@@ -35,7 +35,7 @@ public class Book extends BaseEntity {
 
     private LocalDate publishedDate;
 
-    @Column(nullable = false, length = 13)
+    @Column(nullable = false, length = 13, unique = true)
     private String isbn;
 
     @Setter

--- a/src/main/java/com/example/bookjourneybackend/domain/room/controller/RoomController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/controller/RoomController.java
@@ -1,10 +1,7 @@
 package com.example.bookjourneybackend.domain.room.controller;
 
 import com.example.bookjourneybackend.domain.room.dto.request.PostRoomCreateRequest;
-import com.example.bookjourneybackend.domain.room.dto.response.GetRoomDetailResponse;
-import com.example.bookjourneybackend.domain.room.dto.response.GetRoomInfoResponse;
-import com.example.bookjourneybackend.domain.room.dto.response.GetRoomSearchResponse;
-import com.example.bookjourneybackend.domain.room.dto.response.PostRoomCreateResponse;
+import com.example.bookjourneybackend.domain.room.dto.response.*;
 import com.example.bookjourneybackend.domain.room.service.RoomService;
 import com.example.bookjourneybackend.global.annotation.LoginUserId;
 import com.example.bookjourneybackend.global.response.BaseResponse;
@@ -45,7 +42,6 @@ public class RoomController {
             @RequestParam(required = false) Integer recordCount,
             @RequestParam(required = false) Integer page
     ) {
-
         return BaseResponse.ok(
                 roomService.searchRooms(searchTerm, searchType, genre, recruitStartDate, recruitEndDate, roomStartDate, roomEndDate, recordCount, page)
         );
@@ -55,5 +51,11 @@ public class RoomController {
     public BaseResponse<PostRoomCreateResponse> createRoom(@RequestBody @Valid final PostRoomCreateRequest postRoomCreateRequest,
                                                            @LoginUserId final Long userId) {
         return BaseResponse.ok(roomService.createRoom(postRoomCreateRequest, userId));
+    }
+
+    @GetMapping("/record")
+    public BaseResponse<GetRoomActiveResponse> viewActiveRooms(@RequestParam(required = false) final String sort,
+                                                               @LoginUserId final Long userId) {
+        return BaseResponse.ok(roomService.searchActiveRooms(sort, userId));
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/room/domain/SearchType.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/domain/SearchType.java
@@ -21,7 +21,7 @@ public enum SearchType {
         this.queryType = queryType;
     }
 
-    public static SearchType from(String description) throws GlobalException {
+    public static SearchType from(String description) {
         for (SearchType type : SearchType.values()) {
             if (type.description.equals(description)) {
                 return type;

--- a/src/main/java/com/example/bookjourneybackend/domain/room/domain/SortType.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/domain/SortType.java
@@ -1,0 +1,28 @@
+package com.example.bookjourneybackend.domain.room.domain;
+
+import com.example.bookjourneybackend.global.exception.GlobalException;
+import lombok.Getter;
+
+import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.INVALID_SEARCH_TYPE;
+import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.INVALID_SORT_TYPE;
+
+@Getter
+public enum SortType {
+    LASTEST("최신순"),
+    PROGRESS("진행도순");
+
+    private final String sortType;
+
+    SortType(String sortType) {
+        this.sortType = sortType;
+    }
+
+    public static SortType from(String searchType) {
+        for (SortType type : SortType.values()) {
+            if (type.getSortType().equals(searchType)) {
+                return type;
+            }
+        }
+        throw new GlobalException(INVALID_SORT_TYPE);
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/room/domain/SortType.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/domain/SortType.java
@@ -3,7 +3,6 @@ package com.example.bookjourneybackend.domain.room.domain;
 import com.example.bookjourneybackend.global.exception.GlobalException;
 import lombok.Getter;
 
-import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.INVALID_SEARCH_TYPE;
 import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.INVALID_SORT_TYPE;
 
 @Getter
@@ -17,9 +16,9 @@ public enum SortType {
         this.sortType = sortType;
     }
 
-    public static SortType from(String searchType) {
+    public static SortType from(String sortType) {
         for (SortType type : SortType.values()) {
-            if (type.getSortType().equals(searchType)) {
+            if (type.getSortType().equals(sortType)) {
                 return type;
             }
         }

--- a/src/main/java/com/example/bookjourneybackend/domain/room/dto/request/PostRoomCreateRequest.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/dto/request/PostRoomCreateRequest.java
@@ -1,5 +1,6 @@
 package com.example.bookjourneybackend.domain.room.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,6 +12,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class PostRoomCreateRequest {
 
+    @JsonProperty("isPublic")
     private boolean isPublic;
 
     @Size(max = 20, message = "방 제목은 20자 이내입니다.")

--- a/src/main/java/com/example/bookjourneybackend/domain/room/dto/response/GetRoomActiveResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/dto/response/GetRoomActiveResponse.java
@@ -1,0 +1,22 @@
+package com.example.bookjourneybackend.domain.room.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class GetRoomActiveResponse {
+
+    private List<RecordInfo> recordList;
+
+    public GetRoomActiveResponse(List<RecordInfo> recordList) {
+        this.recordList = recordList;
+    }
+
+    public static GetRoomActiveResponse of(List<RecordInfo> recordList) {
+        return new GetRoomActiveResponse(recordList);
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/room/dto/response/RecordInfo.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/dto/response/RecordInfo.java
@@ -1,0 +1,19 @@
+package com.example.bookjourneybackend.domain.room.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class RecordInfo {
+
+    private final Long roomId;
+    private final String imageUrl;
+    private final String bookTitle;
+    private final String authorName;
+    private final String roomType;
+    private final String modifiedAt;
+    private final Double userPercentage;
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.example.bookjourneybackend.domain.room.domain.SortType.LASTEST;
 import static com.example.bookjourneybackend.global.entity.EntityStatus.*;
 import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.*;
 
@@ -266,9 +267,6 @@ public class RoomService {
     /**
      * 방의 모집종료 기간 = {(방의 종료기간 - 방의 시작기간)/2} + 방의 시작기간
      *
-     * @param startDate
-     * @param progressEndDate
-     * @return
      */
     private LocalDate calculateRecruitEndDate(LocalDate startDate, LocalDate progressEndDate) {
         long totalDays = ChronoUnit.DAYS.between(startDate, progressEndDate);
@@ -284,14 +282,13 @@ public class RoomService {
     /**
      * 최신순, 유저 진행도순 정렬
      * 방이 ACTIVE인 것만 보여줌
-     * @param sort
-     * @param userId
-     * @return
      */
     //todo 추후에 예외처리 메시지 수정
     @Transactional(readOnly = true)
     public GetRoomActiveResponse searchActiveRooms(String sort, Long userId) {
-        SortType sortType = (sort == null)? SortType.LASTEST : SortType.from(sort);
+        log.info("------------------------[RoomService.searchActiveRooms]------------------------");
+        log.info("sort: {}", sort);
+        SortType sortType = (sort == null)? LASTEST : SortType.from(sort);
         List<UserRoom> userRooms;
 
         switch (sortType) {

--- a/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
@@ -2,8 +2,24 @@ package com.example.bookjourneybackend.domain.userRoom.domain.repository;
 
 import com.example.bookjourneybackend.domain.userRoom.domain.UserRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface UserRoomRepository extends JpaRepository<UserRoom, Long> {
+    //JOIN FETCH를 쓴 이유? -> JPA의 N+1 문제를 해결하기 위함..
+    @Query("SELECT ur FROM UserRoom ur " +
+            "JOIN FETCH ur.room r " +
+            "WHERE ur.user.userId = :userId AND r.status = 'ACTIVE' " +
+            "ORDER BY ur.userPercentage DESC")
+    List<UserRoom> findUserRoomsByUserIdAndActiveRoomsOrderByUserPercentage(@Param("userId") Long userId);
+
+    @Query("SELECT ur FROM UserRoom ur " +
+            "JOIN FETCH ur.room r " +
+            "WHERE ur.user.userId = :userId AND r.status = 'ACTIVE' " +
+            "ORDER BY (SELECT MAX(rec.modifiedAt) FROM Record rec WHERE rec.room = r) DESC ")
+    List<UserRoom> findUserRoomsByUserIdAndActiveRoomsOrderByRecordModifiedAt(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
@@ -1,6 +1,8 @@
 package com.example.bookjourneybackend.domain.userRoom.domain.repository;
 
+import com.example.bookjourneybackend.domain.user.domain.User;
 import com.example.bookjourneybackend.domain.userRoom.domain.UserRoom;
+import com.example.bookjourneybackend.global.entity.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,16 +12,16 @@ import java.util.List;
 
 @Repository
 public interface UserRoomRepository extends JpaRepository<UserRoom, Long> {
-    //JOIN FETCH를 쓴 이유? -> JPA의 N+1 문제를 해결하기 위함..
     @Query("SELECT ur FROM UserRoom ur " +
             "JOIN FETCH ur.room r " +
-            "WHERE ur.user.userId = :userId AND r.status = 'ACTIVE' " +
-            "ORDER BY ur.userPercentage DESC")
-    List<UserRoom> findUserRoomsByUserIdAndActiveRoomsOrderByUserPercentage(@Param("userId") Long userId);
+            "WHERE ur.user.userId = :userId AND ur.status = 'ACTIVE' " +
+            "ORDER BY (SELECT MAX(rec.modifiedAt) FROM Record rec WHERE rec.room = r) DESC ")
+    List<UserRoom> findUserRoomsByUserIdAndActiveRoomsOrderByRecordModifiedAt(@Param("userId") Long userId);
 
     @Query("SELECT ur FROM UserRoom ur " +
             "JOIN FETCH ur.room r " +
-            "WHERE ur.user.userId = :userId AND r.status = 'ACTIVE' " +
-            "ORDER BY (SELECT MAX(rec.modifiedAt) FROM Record rec WHERE rec.room = r) DESC ")
-    List<UserRoom> findUserRoomsByUserIdAndActiveRoomsOrderByRecordModifiedAt(@Param("userId") Long userId);
+            "WHERE ur.user.userId = :userId AND ur.status = 'ACTIVE' " +
+            "ORDER BY ur.userPercentage DESC")
+    List<UserRoom> findUserRoomsByUserIdAndActiveRoomsOrderByUserPercentage(@Param("userId") Long userId);
+
 }

--- a/src/main/java/com/example/bookjourneybackend/global/config/initData/BookInitializer.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/initData/BookInitializer.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -15,13 +16,17 @@ public class BookInitializer {
     private final BookRepository bookRepository;
 
     public void initializeBooks() {
+        long baseIsbn = 1234567891011L; // 시작 ISBN 값
+
         for (int i = 1; i <= 100; i++) {
+            String uniqueIsbn = String.valueOf(baseIsbn + i);
+
             Book book = Book.builder()
                     .genre(GenreType.NOVEL_POETRY_DRAMA)
                     .bookTitle("Book Title " + i)
                     .publisher("Publisher " + i)
                     .publishedDate(LocalDate.of(2020, 1, 1))
-                    .isbn("123456789012" + i % 10)
+                    .isbn(uniqueIsbn)
                     .pageCount(200 + i)
                     .description("Description for Book " + i)
                     .authorName("Author " + i)
@@ -30,6 +35,11 @@ public class BookInitializer {
                     .build();
             bookRepository.save(book);
         }
+    }
+
+    // 고유한 ISBN 생성 (UUID 활용)
+    private String generateUniqueIsbn() {
+        return UUID.randomUUID().toString().replaceAll("-", "").substring(0, 13); // 13자리 ISBN 생성
     }
 }
 

--- a/src/main/java/com/example/bookjourneybackend/global/config/initData/UserRoomInitializer.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/initData/UserRoomInitializer.java
@@ -10,12 +10,9 @@ import com.example.bookjourneybackend.domain.userRoom.domain.repository.UserRoom
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 import jakarta.transaction.Transactional;
-import org.springframework.stereotype.Component;
-
 import java.util.List;
+import java.util.Random;
 
 @Component
 @RequiredArgsConstructor
@@ -24,29 +21,34 @@ public class UserRoomInitializer {
     private final UserRoomRepository userRoomRepository;
     private final UserRepository userRepository;
     private final RoomRepository roomRepository;
+    private final Random random = new Random(); // 랜덤 객체 생성
 
-    @Transactional // 트랜잭션 추가
+    @Transactional
     public void initializeUserRooms() {
-        List<User> users = userRepository.findAll(); // User 리스트 로드
-        List<Room> rooms = roomRepository.findAll(); // Room 리스트 로드
+        List<User> users = userRepository.findAll();
+        List<Room> rooms = roomRepository.findAll();
+
+        if (users.isEmpty() || rooms.isEmpty()) {
+            throw new IllegalStateException("Users 또는 Rooms가 존재하지 않습니다. 초기 데이터를 확인하세요.");
+        }
 
         for (int i = 0; i < users.size(); i++) {
-            User user = users.get(i);
-            Room room = rooms.get(i % rooms.size());
+            User user = users.get(random.nextInt(users.size())); // 랜덤한 User 선택
+            Room room = rooms.get(i % rooms.size()); // 방 선택 (순환)
+
+            double randomPercentage = Math.round((Math.random() * 100.0) * 10) / 10.0; // 0~100 사이 소수점 첫째 자리까지
 
             UserRoom userRoom = UserRoom.builder()
                     .user(user)
                     .room(room)
-                    .userRole(i % 2 == 0 ? UserRole.HOST : UserRole.MEMBER)
-                    .userPercentage(0.0)
+                    .userRole(random.nextBoolean() ? UserRole.HOST : UserRole.MEMBER) // 랜덤한 역할
+                    .userPercentage(randomPercentage)
                     .currentPage(1)
                     .build();
 
-            // 연관관계 설정
-            room.addUserRoom(userRoom); // Room과 UserRoom의 연관관계 설정
-            user.addUserRoom(userRoom); // User와 UserRoom의 연관관계 설정
+            room.addUserRoom(userRoom);
+            user.addUserRoom(userRoom);
 
-            // UserRoom 저장
             userRoomRepository.save(userRoom);
         }
     }

--- a/src/main/java/com/example/bookjourneybackend/global/handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/example/bookjourneybackend/global/handler/GlobalControllerAdvice.java
@@ -40,7 +40,7 @@ public class GlobalControllerAdvice {
 
     //API 예외
     @ResponseStatus(BAD_REQUEST)
-    @ExceptionHandler(RuntimeException.class)
+    @ExceptionHandler({GlobalException.class, RuntimeException.class})
     public BaseErrorResponse handleRestApiException(GlobalException e) {
         log.error("[handle_RestApiException]", e);
         return new BaseErrorResponse(e.getExceptionStatus(), e.getMessage());

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -52,6 +52,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     CANNOT_FIND_ROOM(8001 ,BAD_REQUEST, "방을 찾을 수 없습니다."),
     INVALID_ROOM_TYPE(8002, BAD_REQUEST, "알맞은 방 타입을 찾을 수 없습니다."),
     INVALID_SEARCH_TYPE(8003, BAD_REQUEST, "알맞은 검색 조건을 찾을 수 없습니다."),
+    INVALID_SORT_TYPE(8004, BAD_REQUEST, "알맞은 정렬 조건을 찾을 수 없습니다."),
 
     /**
      * 9000 : record 관련


### PR DESCRIPTION
## #️⃣연관된 이슈

- closed #66 

## 📝작업 내용

> 홈화면에서 사용자가 진행 중인 기록을 조회하는 기능을 구현하였습니다.
- 최신순(default) - 가장 최근에 기록이 갱신된 방을 오름차순으로 정렬
- 진행도 순 - 사용자의 해당 방의 진행도 순을 기준으로 내림차순 정렬 (UserRoom의 userPercentage 이용)


<img width="645" alt="스크린샷 2025-01-29 오전 1 13 05" src="https://github.com/user-attachments/assets/d9475805-ad8d-4ed2-996a-1c5cedd238bf" />

### 스크린샷 (선택)
<img width="847" alt="스크린샷 2025-01-29 오전 1 36 44" src="https://github.com/user-attachments/assets/39333dc4-bd3a-4d0b-8ec6-5d4a1bef0cf6" />

## 💬리뷰 요구사항(선택)

> 추가적으로 더미 데이터를 수정하였습니다.
- Book엔티티에 고유한 isbn만 들어가도록 수정하였습니다.
- UserRoom에 랜덤하게 User가 매핑되도록 하였습니다. 
- UserRoom에 userPercentage 또한 랜덤하게 배정되도록 하였습니다. (소수점 한자리까지 반올림)
