### PR TITLE
[FEAT] 진행 중인 기록 삭제 구현

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
@@ -26,7 +26,7 @@ public class RecordService {
     @Transactional
     public PostRecordResponse createRecord(PostRecordRequest postRecordRequest, Long roomId, Long userId) {
 
-        Room room = roomRepository.findById(roomId).orElseThrow(() -> new GlobalException(CANNOT_FIND_ROOM));
+        Room room = roomRepository.findById(roomId).orElseThrow(() -> new GlobalException(CANNOT_FOUND_ROOM));
         User user = userRepository.findById(userId).orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
 
         // recordType에 따른 필수값 검증

--- a/src/main/java/com/example/bookjourneybackend/domain/room/controller/RoomController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/controller/RoomController.java
@@ -53,9 +53,15 @@ public class RoomController {
         return BaseResponse.ok(roomService.createRoom(postRoomCreateRequest, userId));
     }
 
-    @GetMapping("/record")
+    @GetMapping("/records")
     public BaseResponse<GetRoomActiveResponse> viewActiveRooms(@RequestParam(required = false) final String sort,
                                                                @LoginUserId final Long userId) {
         return BaseResponse.ok(roomService.searchActiveRooms(sort, userId));
+    }
+
+    @PutMapping("/{roomId}/records")
+    public BaseResponse<Void> deleteActiveRooms(@PathVariable("roomId") final Long roomId,
+                                                @LoginUserId final Long userId) {
+        return BaseResponse.ok(roomService.putRoomsInactive(roomId, userId));
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
@@ -294,10 +294,10 @@ public class RoomService {
 
         switch (sortType) {
             //최신순 정렬
-            case LASTEST -> userRooms = userRoomRepository.findUserRoomsByUserIdAndActiveRoomsOrderByRecordModifiedAt(userId);
+            case LASTEST -> userRooms = userRoomRepository.findUserRoomsOrderByModifiedAt(userId);
 
             //유저 진행도순 정렬
-            case PROGRESS -> userRooms = userRoomRepository.findUserRoomsByUserIdAndActiveRoomsOrderByUserPercentage(userId);
+            case PROGRESS -> userRooms = userRoomRepository.findUserRoomsOrderByUserPercentage(userId);
 
             default -> throw new GlobalException(INVALID_SORT_TYPE);
         }

--- a/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
@@ -19,6 +19,7 @@ import com.example.bookjourneybackend.domain.user.domain.repository.UserReposito
 import com.example.bookjourneybackend.domain.userRoom.domain.UserRole;
 import com.example.bookjourneybackend.domain.userRoom.domain.UserRoom;
 import com.example.bookjourneybackend.domain.userRoom.domain.repository.UserRoomRepository;
+import com.example.bookjourneybackend.global.entity.EntityStatus;
 import com.example.bookjourneybackend.global.exception.GlobalException;
 import com.example.bookjourneybackend.domain.record.domain.Record;
 import lombok.RequiredArgsConstructor;
@@ -55,7 +56,7 @@ public class RoomService {
 
     public GetRoomDetailResponse showRoomDetails(Long roomId) {
         Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new GlobalException(CANNOT_FIND_ROOM));
+                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_ROOM));
         List<RoomMemberInfo> members = getRoomMemberInfoList(room);
 
         LocalDate recruitEndDate = room.getRecruitEndDate(); // recruitEndDate를 Room 객체에서 직접 가져옴
@@ -78,7 +79,7 @@ public class RoomService {
 
     public GetRoomInfoResponse showRoomInfo(Long roomId) {
         Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new GlobalException(CANNOT_FIND_ROOM));
+                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_ROOM));
         List<RoomMemberInfo> members = getRoomMemberInfoList(room);
 
         return GetRoomInfoResponse.of(
@@ -325,5 +326,26 @@ public class RoomService {
                 }).toList();
     }
 
+    /**
+     * 진행중인 기록 삭제
+     * UserRoom의 status를 INACTIVE로 변경
+     */
+    @Transactional
+    public Void putRoomsInactive(Long roomId, Long userId) {
+        log.info("------------------------[RoomService.putRoomsInactive]------------------------");
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_ROOM));
 
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
+
+
+        UserRoom userRoom = userRoomRepository.findUserRoomByRoomAndUserAndStatus(room, user, ACTIVE)
+                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER_ROOM));
+
+        userRoom.setStatus(EntityStatus.INACTIVE);
+        userRoomRepository.save(userRoom);
+
+        return null;
+    }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
@@ -1,5 +1,6 @@
 package com.example.bookjourneybackend.domain.userRoom.domain.repository;
 
+import com.example.bookjourneybackend.domain.room.domain.Room;
 import com.example.bookjourneybackend.domain.user.domain.User;
 import com.example.bookjourneybackend.domain.userRoom.domain.UserRoom;
 import com.example.bookjourneybackend.global.entity.EntityStatus;
@@ -9,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface UserRoomRepository extends JpaRepository<UserRoom, Long> {
@@ -23,5 +25,7 @@ public interface UserRoomRepository extends JpaRepository<UserRoom, Long> {
             "WHERE ur.user.userId = :userId AND ur.status = 'ACTIVE' " +
             "ORDER BY ur.userPercentage DESC")
     List<UserRoom> findUserRoomsByUserIdAndActiveRoomsOrderByUserPercentage(@Param("userId") Long userId);
+
+    Optional<UserRoom> findUserRoomByRoomAndUserAndStatus(Room room, User user, EntityStatus status);
 
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
@@ -18,13 +18,13 @@ public interface UserRoomRepository extends JpaRepository<UserRoom, Long> {
             "JOIN FETCH ur.room r " +
             "WHERE ur.user.userId = :userId AND ur.status = 'ACTIVE' " +
             "ORDER BY (SELECT MAX(rec.modifiedAt) FROM Record rec WHERE rec.room = r) DESC ")
-    List<UserRoom> findUserRoomsByUserIdAndActiveRoomsOrderByRecordModifiedAt(@Param("userId") Long userId);
+    List<UserRoom> findUserRoomsOrderByModifiedAt(@Param("userId") Long userId);
 
     @Query("SELECT ur FROM UserRoom ur " +
             "JOIN FETCH ur.room r " +
             "WHERE ur.user.userId = :userId AND ur.status = 'ACTIVE' " +
             "ORDER BY ur.userPercentage DESC")
-    List<UserRoom> findUserRoomsByUserIdAndActiveRoomsOrderByUserPercentage(@Param("userId") Long userId);
+    List<UserRoom> findUserRoomsOrderByUserPercentage(@Param("userId") Long userId);
 
     Optional<UserRoom> findUserRoomByRoomAndUserAndStatus(Room room, User user, EntityStatus status);
 

--- a/src/main/java/com/example/bookjourneybackend/global/entity/BaseEntity.java
+++ b/src/main/java/com/example/bookjourneybackend/global/entity/BaseEntity.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -33,6 +34,7 @@ public abstract class BaseEntity {
     @Column(nullable = false)
     private LocalDateTime modifiedAt;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 50)
     @ColumnDefault("'ACTIVE'")

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -49,10 +49,12 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     /**
      * 8000 : room 관련
      */
-    CANNOT_FIND_ROOM(8001 ,BAD_REQUEST, "방을 찾을 수 없습니다."),
+    CANNOT_FOUND_ROOM(8001 ,BAD_REQUEST, "방을 찾을 수 없습니다."),
     INVALID_ROOM_TYPE(8002, BAD_REQUEST, "알맞은 방 타입을 찾을 수 없습니다."),
     INVALID_SEARCH_TYPE(8003, BAD_REQUEST, "알맞은 검색 조건을 찾을 수 없습니다."),
     INVALID_SORT_TYPE(8004, BAD_REQUEST, "알맞은 정렬 조건을 찾을 수 없습니다."),
+
+    CANNOT_FOUND_USER_ROOM(8005, BAD_REQUEST, "사용자와 방의 관계가 없습니다."),
 
     /**
      * 9000 : record 관련


### PR DESCRIPTION
## #️⃣연관된 이슈

- closed #68 

## 📝작업 내용

> 홈화면에서 진행 중인 기록을 삭제하는 것을 구현하였습니다.
UserRoom의 status를 INACTIVE로 변경하였습니다.

### 스크린샷 (선택)
> 변경되는 것을 테스트를 통해 확인하고, 변경된 방은 조회되지 않는 것까지 테스트하였습니다.
<img width="585" alt="스크린샷 2025-01-29 오전 3 00 08" src="https://github.com/user-attachments/assets/8fa143f2-0df5-4e07-a4eb-fd484cba1f56" />


