### PR TITLE
[FEAT] 페이지 별 기록 조회

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/record/controller/RecordController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/controller/RecordController.java
@@ -1,7 +1,7 @@
 package com.example.bookjourneybackend.domain.record.controller;
 
 import com.example.bookjourneybackend.domain.record.dto.request.PostRecordRequest;
-import com.example.bookjourneybackend.domain.record.dto.response.GetEntireRecordResponse;
+import com.example.bookjourneybackend.domain.record.dto.response.GetRecordResponse;
 import com.example.bookjourneybackend.domain.record.dto.response.PostRecordResponse;
 import com.example.bookjourneybackend.domain.record.service.RecordService;
 import com.example.bookjourneybackend.global.annotation.LoginUserId;
@@ -29,12 +29,23 @@ public class RecordController {
     }
 
     @GetMapping("/{roomId}/entire/{userId}")
-    public BaseResponse<GetEntireRecordResponse> getEntireRecords(
+    public BaseResponse<GetRecordResponse> getEntireRecords(
             @PathVariable("roomId") Long roomId,
             @PathVariable("userId") Long userId,
-            @RequestParam(value = "sortingType", required = false, defaultValue = "최신 등록 순") String sortingType) {
+            @RequestParam(value = "sortingType", required = false, defaultValue = "최신 등록순") String sortingType) {
 
         return BaseResponse.ok(recordService.showEntireRecords(roomId, userId, sortingType));
+    }
+
+    @GetMapping("/{roomId}/page/{userId}")
+    public BaseResponse<GetRecordResponse> getPageRecords(
+            @PathVariable("roomId") Long roomId,
+            @PathVariable("userId") Long userId,
+            @RequestParam(value = "sortingType", required = false, defaultValue = "페이지순") String sortingType,
+            @RequestParam(value = "pageStart", required = false) Integer pageStart,
+            @RequestParam(value = "pageEnd", required = false) Integer pageEnd
+    ) {
+        return BaseResponse.ok(recordService.showPageRecords(roomId, userId, sortingType, pageStart, pageEnd));
     }
 
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/record/controller/RecordController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/controller/RecordController.java
@@ -28,19 +28,19 @@ public class RecordController {
         return BaseResponse.ok(recordService.createRecord(postRecordRequest, roomId, userId));
     }
 
-    @GetMapping("/{roomId}/entire/{userId}")
+    @GetMapping("/{roomId}/entire")
     public BaseResponse<GetRecordResponse> getEntireRecords(
             @PathVariable("roomId") Long roomId,
-            @PathVariable("userId") Long userId,
+            @LoginUserId final Long userId,
             @RequestParam(value = "sortingType", required = false, defaultValue = "최신 등록순") String sortingType) {
 
         return BaseResponse.ok(recordService.showEntireRecords(roomId, userId, sortingType));
     }
 
-    @GetMapping("/{roomId}/page/{userId}")
+    @GetMapping("/{roomId}/page")
     public BaseResponse<GetRecordResponse> getPageRecords(
             @PathVariable("roomId") Long roomId,
-            @PathVariable("userId") Long userId,
+            @LoginUserId final Long userId,
             @RequestParam(value = "sortingType", required = false, defaultValue = "페이지순") String sortingType,
             @RequestParam(value = "pageStart", required = false) Integer pageStart,
             @RequestParam(value = "pageEnd", required = false) Integer pageEnd

--- a/src/main/java/com/example/bookjourneybackend/domain/record/domain/RecordSortType.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/domain/RecordSortType.java
@@ -8,7 +8,7 @@ import static com.example.bookjourneybackend.global.response.status.BaseExceptio
 @Getter
 public enum RecordSortType {
 
-    LATEST("최신 등록 순"), MOST_COMMENTS("답글 많은 순");
+    LATEST("최신 등록순"), MOST_COMMENTS("답글 많은 순"), PAGE_ORDER("페이지순");
 
     private final String recordSortType;
 

--- a/src/main/java/com/example/bookjourneybackend/domain/record/domain/repository/RecordLikeRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/domain/repository/RecordLikeRepository.java
@@ -3,15 +3,12 @@ package com.example.bookjourneybackend.domain.record.domain.repository;
 import com.example.bookjourneybackend.domain.record.domain.Record;
 import com.example.bookjourneybackend.domain.record.domain.RecordLike;
 import com.example.bookjourneybackend.domain.user.domain.User;
+import com.example.bookjourneybackend.global.entity.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RecordLikeRepository extends JpaRepository<RecordLike, Long> {
 
-    @Query("SELECT COUNT(rl) > 0 FROM RecordLike rl " +
-            "WHERE rl.record = :record AND rl.user = :user AND rl.record.status = 'ACTIVE'")
-    boolean existsByRecordAndUser(@Param("record") Record record, @Param("user") User user);
+    boolean existsByRecordAndUserAndRecordStatus(Record record, User user, EntityStatus status);
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/record/domain/repository/RecordRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/domain/repository/RecordRepository.java
@@ -17,4 +17,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 
     @Query("SELECT r FROM Record r WHERE r.room.roomId = :roomId AND r.status = 'ACTIVE' ORDER BY SIZE(r.comments) DESC")
     List<Record> findRecordsOrderByMostComments(@Param("roomId") Long roomId, @Param("sortType") RecordSortType sortType);
+
+    @Query("SELECT r FROM Record r WHERE r.room.roomId = :roomId AND r.status = 'ACTIVE' ORDER BY r.recordPage ASC")
+    List<Record> findRecordsOrderByPage(@Param("roomId") Long roomId, @Param("sortType") RecordSortType sortType);
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/record/domain/repository/RecordRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/domain/repository/RecordRepository.java
@@ -8,16 +8,17 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RecordRepository extends JpaRepository<Record, Long> {
 
     @Query("SELECT r FROM Record r WHERE r.room.roomId = :roomId AND r.status = 'ACTIVE' ORDER BY r.createdAt DESC")
-    List<Record> findRecordsOrderByLatest(@Param("roomId") Long roomId, @Param("sortType") RecordSortType sortType);
+    Optional<List<Record>> findRecordsOrderByLatest(@Param("roomId") Long roomId, @Param("sortType") RecordSortType sortType);
 
     @Query("SELECT r FROM Record r WHERE r.room.roomId = :roomId AND r.status = 'ACTIVE' ORDER BY SIZE(r.comments) DESC")
-    List<Record> findRecordsOrderByMostComments(@Param("roomId") Long roomId, @Param("sortType") RecordSortType sortType);
+    Optional<List<Record>> findRecordsOrderByMostComments(@Param("roomId") Long roomId, @Param("sortType") RecordSortType sortType);
 
     @Query("SELECT r FROM Record r WHERE r.room.roomId = :roomId AND r.status = 'ACTIVE' ORDER BY r.recordPage ASC")
-    List<Record> findRecordsOrderByPage(@Param("roomId") Long roomId, @Param("sortType") RecordSortType sortType);
+    Optional<List<Record>> findRecordsOrderByPage(@Param("roomId") Long roomId, @Param("sortType") RecordSortType sortType);
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/record/dto/response/GetRecordResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/dto/response/GetRecordResponse.java
@@ -7,15 +7,15 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
-public class GetEntireRecordResponse {
+public class GetRecordResponse {
 
     private List<RecordInfo> recordList;
 
-    public GetEntireRecordResponse(List<RecordInfo> entireRecords) {
+    public GetRecordResponse(List<RecordInfo> entireRecords) {
         this.recordList = entireRecords;
     }
 
-    public static GetEntireRecordResponse of(List<RecordInfo> entireRecords) {
-        return new GetEntireRecordResponse(entireRecords);
+    public static GetRecordResponse of(List<RecordInfo> entireRecords) {
+        return new GetRecordResponse(entireRecords);
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/record/dto/response/RecordInfo.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/dto/response/RecordInfo.java
@@ -15,7 +15,7 @@ public class RecordInfo {
     private String imageUrl;
     private String nickName;
     private String recordTitle;  // 전체 기록에서 사용
-    private Integer bookPage;     // 페이지 기록에서 사용
+    private Integer recordPage;     // 페이지 기록에서 사용
     private String createdAt;
     private String content;
     private Integer commentCount;
@@ -23,14 +23,14 @@ public class RecordInfo {
     private boolean isLike;
 
     public static RecordInfo fromPageRecord(Long userId, Long recordId, String imageUrl, String nickName,
-                                            Integer bookPage, String createdAt, String content,
+                                            Integer recordPage, String createdAt, String content,
                                             Integer commentCount, Integer recordLikeCount, boolean isLike) {
         return RecordInfo.builder()
                 .userId(userId)
                 .recordId(recordId)
                 .imageUrl(imageUrl)
                 .nickName(nickName)
-                .bookPage(bookPage)
+                .recordPage(recordPage)
                 .createdAt(createdAt)
                 .content(content)
                 .commentCount(commentCount)

--- a/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
@@ -93,7 +93,7 @@ public class RecordService {
 
         List<Record> records = findRecordsByRoomId(roomId, recordSortType)
                 .stream()
-                .filter(record -> record.getRecordType() == RecordType.ENTIRE)
+                .filter(this::isEntireRecord)
                 .collect(Collectors.toList());
 
         List<RecordInfo> recordInfoList = parseEntireRecordsToResponse(records, user);
@@ -111,15 +111,37 @@ public class RecordService {
         RecordSortType recordSortType = (sortType == null) ? PAGE_ORDER : RecordSortType.from(sortType);
 
         List<Record> records = findRecordsByRoomId(roomId, recordSortType).stream()
-                .filter(record -> record.getRecordType() == RecordType.PAGE)
-                .filter(record -> record.getRecordPage() != null && (
-                        (pageStart == null || record.getRecordPage() >= pageStart) &&
-                                (pageEnd == null || record.getRecordPage() <= pageEnd)
-                ))
+                .filter(this::isPageRecord)
+                .filter(record -> isWithinPageRange(record, pageStart, pageEnd))
                 .collect(Collectors.toList());
 
         List<RecordInfo> recordInfoList = parsePageRecordsToResponse(records, user);
         return GetRecordResponse.of(recordInfoList);
+    }
+
+    /**
+     * 전체 기록인지 확인
+     */
+    private boolean isEntireRecord(Record record) {
+        return record.getRecordType() == RecordType.ENTIRE;
+    }
+
+    /**
+     * 페이지 기록인지 확인
+     */
+    private boolean isPageRecord(Record record) {
+        return record.getRecordType() == RecordType.PAGE;
+    }
+
+
+    /**
+     * 기록의 페이지가 주어진 범위(pageStart, pageEnd) 내에 있는지 확인
+     */
+    private boolean isWithinPageRange(Record record, Integer pageStart, Integer pageEnd) {
+        Integer recordPage = record.getRecordPage();
+        return recordPage != null &&
+                (pageStart == null || recordPage >= pageStart) &&
+                (pageEnd == null || recordPage <= pageEnd);
     }
 
     /**

--- a/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.example.bookjourneybackend.domain.record.domain.RecordSortType.PAGE_ORDER;
 import static com.example.bookjourneybackend.global.entity.EntityStatus.*;
 
 import java.util.List;
@@ -106,7 +107,7 @@ public class RecordService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
 
-        RecordSortType recordSortType = (sortType == null) ? LATEST : RecordSortType.from(sortType);
+        RecordSortType recordSortType = (sortType == null) ? PAGE_ORDER : RecordSortType.from(sortType);
 
         List<Record> records = findRecordsByRoomId(roomId, recordSortType).stream()
                 .filter(record -> record.getRecordType() == RecordType.PAGE)

--- a/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
@@ -26,6 +26,7 @@ import static com.example.bookjourneybackend.domain.record.domain.RecordSortType
 import static com.example.bookjourneybackend.global.entity.EntityStatus.*;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.example.bookjourneybackend.domain.record.domain.RecordSortType.LATEST;
@@ -125,12 +126,14 @@ public class RecordService {
      * roomId와 기록의 정렬 순서로 기록 찾기
      */
     private List<Record> findRecordsByRoomId(Long roomId, RecordSortType sortType) {
-        return switch (sortType) {
+        Optional<List<Record>> records = switch (sortType) {
             case LATEST -> recordRepository.findRecordsOrderByLatest(roomId, sortType);
             case MOST_COMMENTS -> recordRepository.findRecordsOrderByMostComments(roomId, sortType);
             case PAGE_ORDER -> recordRepository.findRecordsOrderByPage(roomId, sortType);
             default -> throw new GlobalException(INVALID_RECORD_SORT_TYPE);
         };
+
+        return records.orElseThrow(() -> new GlobalException(RECORD_NOT_FOUND));
     }
 
     private List<RecordInfo> parseEntireRecordsToResponse(List<Record> records, User user) {

--- a/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
@@ -160,7 +160,7 @@ public class RecordService {
                             record.getRecordId(),
                             (record.getUser().getUserImage() != null) ? record.getUser().getUserImage().getImageUrl() : null,
                             record.getUser().getNickname(),
-                            record.getRoom().getBook().getPageCount(),
+                            record.getRecordPage(),
                             dateUtil.formDateTime(record.getCreatedAt()),
                             record.getContent(),
                             record.getComments().size(),

--- a/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
@@ -161,7 +161,7 @@ public class RecordService {
     private List<RecordInfo> parseEntireRecordsToResponse(List<Record> records, User user) {
         return records.stream()
                 .map(record -> {
-                    boolean isLiked = recordLikeRepository.existsByRecordAndUser(record, user);
+                    boolean isLiked = recordLikeRepository.existsByRecordAndUserAndRecordStatus(record, user, ACTIVE);
                     return RecordInfo.fromEntireRecord(
                             record.getUser().getUserId(),
                             record.getRecordId(),
@@ -180,7 +180,7 @@ public class RecordService {
     private List<RecordInfo> parsePageRecordsToResponse(List<Record> records, User user) {
         return records.stream()
                 .map(record -> {
-                    boolean isLiked = recordLikeRepository.existsByRecordAndUser(record, user);
+                    boolean isLiked = recordLikeRepository.existsByRecordAndUserAndRecordStatus(record, user, ACTIVE);
                     return RecordInfo.fromPageRecord(
                             record.getUser().getUserId(),
                             record.getRecordId(),

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -63,7 +63,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     /**
      * 9000 : record 관련
      */
-    RECORD_NOT_FOUND(9001, BAD_REQUEST, "알맞은 기록 타입을 찾을 수 없습니다."),
+    RECORD_NOT_FOUND(9001, BAD_REQUEST, "기록을 찾을 수 없습니다."),
 
     INVALID_RECORD_TYPE(9002, BAD_REQUEST, "알맞은 기록 타입을 찾을 수 없습니다."),
     INVALID_RECORD_PAGE(9002, BAD_REQUEST, "페이지 번호를 입력해주세요."),


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #62 

## 📝작업 내용

- page(페이지 기록)일때만 조회하기
- 페이지 순, 최신 등록 순, 답글 많은 순으로 정렬하기
- 사용자 팝업에서 pageStart, pageEnd 받아와서 범위 내 것들만 보여주기

### 스크린샷 (선택)

- 페이지 별 조회 (페이지 query param 보내지 않았을 때)
<img width="1822" alt="스크린샷 2025-01-30 오후 8 55 01" src="https://github.com/user-attachments/assets/a375c8a7-690b-40a1-9f93-b48f2e74fa3a" />

- 페이지 범위 param 보냈을 때
<img width="1822" alt="스크린샷 2025-01-30 오후 8 55 17" src="https://github.com/user-attachments/assets/8de00105-926b-44c5-abee-8a02eeb1f91d" />

- 전체 기록으로 요청 보내면 받아오지 않음
<img width="1822" alt="스크린샷 2025-01-30 오후 8 55 28" src="https://github.com/user-attachments/assets/e0941a76-0763-4a40-bb8f-0ce6db13180b" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
