### PR TITLE
[FEAT] 최근 검색어 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/controller/RecentSearchController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/controller/RecentSearchController.java
@@ -1,4 +1,27 @@
 package com.example.bookjourneybackend.domain.recentSearch.controller;
 
+import com.example.bookjourneybackend.domain.recentSearch.domain.dto.response.GetRecentSearchResponse;
+import com.example.bookjourneybackend.domain.recentSearch.service.RecentSearchService;
+import com.example.bookjourneybackend.global.annotation.LoginUserId;
+import com.example.bookjourneybackend.global.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/recent-search")
 public class RecentSearchController {
+
+    private final RecentSearchService recentSearchService;
+
+    @GetMapping()
+    public BaseResponse<GetRecentSearchResponse> viewRecentSearch(@LoginUserId final Long userId) {
+        log.info("[RecentSearchController.viewRecentSearch]");
+        return BaseResponse.ok(recentSearchService.showRecentSearch(userId));
+    }
+
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/dto/response/GetRecentSearchResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/dto/response/GetRecentSearchResponse.java
@@ -1,0 +1,20 @@
+package com.example.bookjourneybackend.domain.recentSearch.domain.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class GetRecentSearchResponse {
+    private List<RecentSearchInfo> recentSearchList;
+
+    public GetRecentSearchResponse(List<RecentSearchInfo> recentSearchList) {
+        this.recentSearchList = recentSearchList;
+    }
+
+    public static GetRecentSearchResponse of(List<RecentSearchInfo> recentSearchList) {
+        return new GetRecentSearchResponse(recentSearchList);
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/dto/response/RecentSearchInfo.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/dto/response/RecentSearchInfo.java
@@ -1,0 +1,11 @@
+package com.example.bookjourneybackend.domain.recentSearch.domain.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RecentSearchInfo {
+    private Long recentSearchId;
+    private String recentSearch;
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/repository/RecentSearchRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/repository/RecentSearchRepository.java
@@ -10,5 +10,6 @@ import java.util.Optional;
 
 @Repository
 public interface RecentSearchRepository extends JpaRepository<RecentSearch, Long> {
-    Optional<List<RecentSearch>> findByUser(User user);
+    Optional<List<RecentSearch>>  findTop12ByUserOrderByCreatedAtDesc(User user);
+
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/repository/RecentSearchRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/repository/RecentSearchRepository.java
@@ -1,9 +1,14 @@
 package com.example.bookjourneybackend.domain.recentSearch.domain.repository;
 
 import com.example.bookjourneybackend.domain.recentSearch.domain.RecentSearch;
+import com.example.bookjourneybackend.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface RecentSearchRepository extends JpaRepository<RecentSearch, Long> {
+    Optional<List<RecentSearch>> findByUser(User user);
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/service/RecentSearchService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/service/RecentSearchService.java
@@ -1,4 +1,63 @@
 package com.example.bookjourneybackend.domain.recentSearch.service;
 
+import com.example.bookjourneybackend.domain.recentSearch.domain.RecentSearch;
+import com.example.bookjourneybackend.domain.recentSearch.domain.dto.response.GetRecentSearchResponse;
+import com.example.bookjourneybackend.domain.recentSearch.domain.dto.response.RecentSearchInfo;
+import com.example.bookjourneybackend.domain.recentSearch.domain.repository.RecentSearchRepository;
+import com.example.bookjourneybackend.domain.user.domain.User;
+import com.example.bookjourneybackend.domain.user.domain.repository.UserRepository;
+import com.example.bookjourneybackend.global.exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_USER;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
 public class RecentSearchService {
+
+    private final RecentSearchRepository recentSearchRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 로그인 한 유저의 최근검색어 리스트 조회
+     * @param userId
+     * @return GetRecentSearchResponse
+     */
+    public GetRecentSearchResponse showRecentSearch(Long userId) {
+        log.info("[RecentSearchService.showRecentSearch]");
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
+
+        //사용자의 최근 검색어 조회
+        Optional<List<RecentSearch>> recentSearchList = recentSearchRepository.findByUser(user);
+
+        return getGetRecentSearchResponse(recentSearchList);
+    }
+
+    private GetRecentSearchResponse getGetRecentSearchResponse(Optional<List<RecentSearch>> recentSearchList) {
+
+        // 최근 검색어 리스트가 존재하면 RecentSearchInfo로 변환하고, 없다면 빈 리스트 반환
+        List<RecentSearchInfo> recentSearchInfoList = recentSearchList
+                .map(list -> list.stream()
+                        .map(recentSearch -> new RecentSearchInfo
+                                (recentSearch.getRecentSearchId(),
+                                recentSearch.getRecentSearch()))
+                        .collect(Collectors.toList()))
+                .orElse(List.of());
+
+        return GetRecentSearchResponse.of(recentSearchInfoList);
+    }
+
+
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/service/RecentSearchService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/service/RecentSearchService.java
@@ -32,6 +32,7 @@ public class RecentSearchService {
      * @param userId
      * @return GetRecentSearchResponse
      */
+    @Transactional(readOnly = true)
     public GetRecentSearchResponse showRecentSearch(Long userId) {
         log.info("[RecentSearchService.showRecentSearch]");
 

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/service/RecentSearchService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/service/RecentSearchService.java
@@ -40,7 +40,7 @@ public class RecentSearchService {
                 .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
 
         //사용자의 최근 검색어 조회
-        Optional<List<RecentSearch>> recentSearchList = recentSearchRepository.findByUser(user);
+        Optional<List<RecentSearch>> recentSearchList = recentSearchRepository.findTop12ByUserOrderByCreatedAtDesc(user);
 
         return getGetRecentSearchResponse(recentSearchList);
     }

--- a/src/main/java/com/example/bookjourneybackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
 
     private static final String[] AUTH_WHITELIST = {
             "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
-            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html",
+            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html","/swagger-ui/index.html",
             "/auth/login","/auth/reissue",
             "/users/signup","/users/emails/verification-requests","/users/emails/verifications",
             "/users/nickname","/h2-console/**"
@@ -74,7 +74,10 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("*"));  //모든출처 허용
+        configuration.setAllowedOrigins(Arrays.asList(
+                "http://localhost:3000",  // 로컬 환경
+                "http://ec2-13-48-61-179.eu-north-1.compute.amazonaws.com"  // 배포 환경
+        ));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PATCH", "DELETE","PUT","OPTIONS"));  // 허용할 HTTP 메서드 설정
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type","Refresh-Token"));  // 허용할 헤더 설정
         configuration.setAllowCredentials(true);  // 자격 증명 허용 설정


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #16 

## 📝작업 내용

![image](https://github.com/user-attachments/assets/f7e25b90-9e3b-4985-be17-31968c987ae1)
- 최근 검색어 조회 기능을 구현했습니다
- 사용자별로 최근 검색어를 최신순으로 최대 12개 보여줍니다.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/21eca34e-c0f6-4728-a9da-bceeab116f21)
![image](https://github.com/user-attachments/assets/470ac6ff-67dd-4311-870d-0acd024f936f)
사용자별로 최근 검색어 리스트가 제대로 반환되는 모습을 확인할 수 있습니다!
