### PR TITLE
[FEAT] 최근검색어 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/controller/RecentSearchController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/controller/RecentSearchController.java
@@ -6,9 +6,7 @@ import com.example.bookjourneybackend.global.annotation.LoginUserId;
 import com.example.bookjourneybackend.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -22,6 +20,12 @@ public class RecentSearchController {
     public BaseResponse<GetRecentSearchResponse> viewRecentSearch(@LoginUserId final Long userId) {
         log.info("[RecentSearchController.viewRecentSearch]");
         return BaseResponse.ok(recentSearchService.showRecentSearch(userId));
+    }
+
+    @DeleteMapping("/{recentSearchId}")
+    public BaseResponse<Void> deleteRecentSearch(@PathVariable("recentSearchId") final Long recentSearchId,@LoginUserId final Long userId) {
+        log.info("[RecentSearchController.deleteRecentSearch]");
+        return BaseResponse.ok(recentSearchService.deleteRecentSearch(recentSearchId,userId));
     }
 
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/repository/RecentSearchRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/repository/RecentSearchRepository.java
@@ -11,4 +11,5 @@ import java.util.Optional;
 @Repository
 public interface RecentSearchRepository extends JpaRepository<RecentSearch, Long> {
     Optional<List<RecentSearch>> findByUser(User user);
+    Optional<RecentSearch> findByUserAndRecentSearchId(User user, Long recentSearchId);
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/repository/RecentSearchRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/repository/RecentSearchRepository.java
@@ -11,7 +11,5 @@ import java.util.Optional;
 @Repository
 public interface RecentSearchRepository extends JpaRepository<RecentSearch, Long> {
     Optional<List<RecentSearch>>  findTop12ByUserOrderByCreatedAtDesc(User user);
-
-    Optional<List<RecentSearch>> findByUser(User user);
     Optional<RecentSearch> findByUserAndRecentSearchId(User user, Long recentSearchId);
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/service/RecentSearchService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/service/RecentSearchService.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_RECENT_SEARCH;
 import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_USER;
 
 @Slf4j
@@ -60,4 +61,17 @@ public class RecentSearchService {
     }
 
 
+    public Void deleteRecentSearch(Long recentSearchId, Long userId) {
+        log.info("[RecentSearchService.deleteRecentSearch]");
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
+
+        //사용자가 삭제하고자 하는 최근 검색어 조회
+        RecentSearch recentSearch = recentSearchRepository.findByUserAndRecentSearchId(user, recentSearchId)
+                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_RECENT_SEARCH));
+
+        recentSearchRepository.delete(recentSearch);
+        return null;
+    }
 }

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -82,7 +82,12 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     INVALID_RECORD_PAGE(9002, BAD_REQUEST, "페이지 번호를 입력해주세요."),
     INVALID_RECORD_TITLE(9002, BAD_REQUEST, "기록 제목을 입력해주세요."),
 
-    INVALID_RECORD_SORT_TYPE(9003, BAD_REQUEST, "알맞은 기록 나열 타입을 찾을 수 없습니다.");
+    INVALID_RECORD_SORT_TYPE(9003, BAD_REQUEST, "알맞은 기록 나열 타입을 찾을 수 없습니다."),
+
+    /**
+     * 10000 : recentSearch 관련
+     */
+    CANNOT_FOUND_RECENT_SEARCH(10000,BAD_REQUEST, "최근검색어를 찾을 수 없습니다.");
 
     private final int code;
     private final HttpStatus status;


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #18 

## 📝작업 내용

- 최근 검색어 삭제 기능을 구현했습니다.
- `@ PathVariable` 로 넘어온 최근 검색어가 로그인한 유저가 작성한 최근검색어일 경우 db에서 삭제됩니다.
- 유저가 작성하지않은 최근검색어id가 넘어올 경우 예외처리가 됩니다.

### 스크린샷 (선택)
유저가 등록한 최근검색어가 아닐경우 예외처리
![image](https://github.com/user-attachments/assets/866a7b18-c9b2-44b2-851e-ad090f28caf2)

![image](https://github.com/user-attachments/assets/7e079b2d-79fd-4355-a1b5-10695ecc35a1)
![image](https://github.com/user-attachments/assets/fb7d5c6b-441a-4c46-8c20-e800155a6480)
유저id가 2인 유저가 검색한 최근검색어id가 2인 최근검색어가 성공적으로 db에서 삭제되는 모습을 확인 할 수 있습니다!

## 💬리뷰 요구사항(선택)

> 최근검색어 조회 기능 커밋과 같이보입니다.. ㅜ..ㅜ 
