### PR TITLE
[FEAT] 최근 검색어 모두 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/controller/RecentSearchController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/controller/RecentSearchController.java
@@ -28,4 +28,10 @@ public class RecentSearchController {
         return BaseResponse.ok(recentSearchService.deleteRecentSearch(recentSearchId,userId));
     }
 
+    @DeleteMapping("/all")
+    public BaseResponse<Void> deleteRecentSearchAll(@LoginUserId final Long userId) {
+        log.info("[RecentSearchController.deleteRecentSearchAll]");
+        return BaseResponse.ok(recentSearchService.deleteRecentSearchAll(userId));
+    }
+
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/repository/RecentSearchRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/repository/RecentSearchRepository.java
@@ -11,5 +11,6 @@ import java.util.Optional;
 @Repository
 public interface RecentSearchRepository extends JpaRepository<RecentSearch, Long> {
     Optional<List<RecentSearch>>  findTop12ByUserOrderByCreatedAtDesc(User user);
+    Optional<List<RecentSearch>>  findByUser(User user);
     Optional<RecentSearch> findByUserAndRecentSearchId(User user, Long recentSearchId);
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/service/RecentSearchService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/service/RecentSearchService.java
@@ -16,8 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_RECENT_SEARCH;
-import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_USER;
+import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.*;
 
 @Slf4j
 @Service
@@ -86,7 +85,12 @@ public class RecentSearchService {
     public Void deleteRecentSearchAll(Long userId) {
         log.info("[RecentSearchService.deleteRecentSearchAll]");
 
-        Optional<List<RecentSearch>> recentSearchList = getRecentSearchList(userId);
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
+
+        //사용자의 최근 검색어 조회
+        Optional<List<RecentSearch>> recentSearchList = recentSearchRepository.findByUser(user);
 
         // 최근 검색어가 존재하면 전체 삭제
         if (recentSearchList.isPresent() && !recentSearchList.get().isEmpty()) {
@@ -98,14 +102,4 @@ public class RecentSearchService {
         throw new GlobalException(CANNOT_DELETE_RECENT_SEARCH);
     }
 
-    private Optional<List<RecentSearch>> getRecentSearchList(Long userId) {
-
-        // 사용자 조회
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
-
-        //사용자의 최근 검색어 조회
-        Optional<List<RecentSearch>> recentSearchList = recentSearchRepository.findByUser(user);
-        return recentSearchList;
-    }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/service/RecentSearchService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/service/RecentSearchService.java
@@ -94,7 +94,6 @@ public class RecentSearchService {
 
         // 최근 검색어가 존재하면 전체 삭제
         if (recentSearchList.isPresent() && !recentSearchList.get().isEmpty()) {
-            // 삭제
             recentSearchRepository.deleteAll(recentSearchList.get());
             return null;
         }

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/service/RecentSearchService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/service/RecentSearchService.java
@@ -60,7 +60,10 @@ public class RecentSearchService {
         return GetRecentSearchResponse.of(recentSearchInfoList);
     }
 
-
+    /**
+     * 로그인 한 유저의 특정 최근 검색어 삭제
+     * @param recentSearchId,userId
+     */
     public Void deleteRecentSearch(Long recentSearchId, Long userId) {
         log.info("[RecentSearchService.deleteRecentSearch]");
         // 사용자 조회

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -87,7 +87,8 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     /**
      * 10000 : recentSearch 관련
      */
-    CANNOT_FOUND_RECENT_SEARCH(10000,BAD_REQUEST, "최근검색어를 찾을 수 없습니다.");
+    CANNOT_FOUND_RECENT_SEARCH(10000,BAD_REQUEST, "최근검색어를 찾을 수 없습니다."),
+    CANNOT_DELETE_RECENT_SEARCH(10000,BAD_REQUEST, "최근검색어를 삭제 할 수 없습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -88,7 +88,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
      * 10000 : recentSearch 관련
      */
     CANNOT_FOUND_RECENT_SEARCH(10000,BAD_REQUEST, "최근검색어를 찾을 수 없습니다."),
-    CANNOT_DELETE_RECENT_SEARCH(10000,BAD_REQUEST, "최근검색어를 삭제 할 수 없습니다.");
+    CANNOT_DELETE_RECENT_SEARCH(10001,BAD_REQUEST, "최근검색어를 삭제 할 수 없습니다.");
 
     private final int code;
     private final HttpStatus status;


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #17 

## 📝작업 내용

- 최근 검색어 모두 삭제 기능을 구현했습니다.
- 로그인 한 유저의 최근 검색어를 모두 삭제합니다.
- 후에 사용자의 최근 검색어가 12개가 넘었을시 삭제하는 로직에 따라서 `findTop12ByUserOrderByCreatedAtDesc` 메서드를 재사용 할 수 도 있을 것 같습니다! 추후에 정확하게 픽스되면 리펙토링 하도록하겠습니다
- 사용자가 삭제할 검색어가 없을경우 예외처리를 진행했습니다.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/6b1bba14-fb2e-4fb8-9824-c72626ceaf36)
![image](https://github.com/user-attachments/assets/370a4624-2c6b-4728-9a87-08139f6115d4)
정상적으로 사용자의 최근 검색어가 전체 삭제되는 것을 확인할 수 있습니다!

![image](https://github.com/user-attachments/assets/fb3fc029-1163-44de-bcb0-c06e56110e90)
전체 삭제 요청을 두번 날릴 시 삭제할 검색어가 없기 때문에 예외처리가 됩니다.
