### PR TITLE
[FEAT] 읽은 페이지 입력 시 페이지 조회

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/room/controller/RoomController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/controller/RoomController.java
@@ -88,4 +88,12 @@ public class RoomController {
     ) {
         return BaseResponse.ok(roomService.searchRecruitmentRooms());
     }
+
+    @GetMapping("/{roomId}/pages")
+    public BaseResponse<GetRoomPagesResponse> viewPages(
+            @PathVariable("roomId") final Long roomId,
+            @LoginUserId final Long userId
+    ) {
+        return BaseResponse.ok(roomService.showRoomPages(roomId, userId));
+    }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/room/dto/response/GetRoomPagesResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/dto/response/GetRoomPagesResponse.java
@@ -1,0 +1,15 @@
+package com.example.bookjourneybackend.domain.room.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetRoomPagesResponse {
+    private int bookPage;
+    private int currentPage;
+
+    public static GetRoomPagesResponse of(int bookPage, int currentPage) {
+        return new GetRoomPagesResponse(bookPage, currentPage);
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
@@ -61,7 +61,7 @@ public class RoomService {
      */
     public GetRoomDetailResponse showRoomDetails(Long roomId, Long userId) {
         log.info("------------------------[RoomService.showRoomDetails]------------------------");
-      
+
         Room room = roomRepository.findById(roomId)
                 .orElseThrow(() -> new GlobalException(CANNOT_FOUND_ROOM));
         User user = userRepository.findById(userId)
@@ -248,7 +248,7 @@ public class RoomService {
         String requestUrl = aladinApiUtil.buildLookUpApiUrl(isbn);
         String currentResponse = aladinApiUtil.requestBookInfoFromAladinApi(requestUrl);
 
-        return aladinApiUtil.parseAladinApiResponseToBook(currentResponse,false,0);
+        return aladinApiUtil.parseAladinApiResponseToBook(currentResponse, false, 0);
     }
 
     //유저 정보를 통해 UserRoom 객체 생성
@@ -369,7 +369,7 @@ public class RoomService {
         if (room.getRoomType() == TOGETHER) {
             handleTogetherRoomExit(userRoom, room);
         }
-        if(room.getRoomType() == ALONE) {
+        if (room.getRoomType() == ALONE) {
             roomRepository.delete(room);    // 혼자읽기 방은 나가면 방 삭제
         }
 
@@ -476,5 +476,21 @@ public class RoomService {
                                 .build())
                         .toList()
         );
+    }
+
+    /**
+     * 읽은 페이지 입력 시 책 전체 & 저번까지 읽었던 페이지 조회
+     */
+    @Transactional(readOnly = true)
+    public GetRoomPagesResponse showRoomPages(Long roomId, Long userId) {
+        Room room = roomRepository.findById(roomId).orElseThrow(() -> new GlobalException(CANNOT_FOUND_ROOM));
+        User user = userRepository.findById(userId).orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
+        UserRoom userRoom = userRoomRepository.findUserRoomByRoomAndUser(room, user).orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER_ROOM));
+
+        int bookPage = room.getBook().getPageCount();
+        int currentPage = userRoom.getCurrentPage();
+
+        return GetRoomPagesResponse.of(bookPage, currentPage);
+
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #87 

## 📝작업 내용

- 어디까지 읽었는지 기록할 때 전에 얼마나 읽었는지와 책의 전체 페이지 정보를 조회합니다

### 스크린샷 (선택)

- 페이지 입력 전 & 후 받아온 상황입니다
<img width="1392" alt="스크린샷 2025-02-03 오후 2 54 51" src="https://github.com/user-attachments/assets/dfc8867b-718a-4586-b616-90a996877c1b" />
<img width="1392" alt="스크린샷 2025-02-03 오후 2 54 54" src="https://github.com/user-attachments/assets/7f00f4c7-4ab0-4fa1-bb99-b4a80e5865a0" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
