### PR TITLE
[FEAT] 즐겨찾기 추가 기능 구현

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BookCacheService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BookCacheService.java
@@ -50,6 +50,7 @@ public class BookCacheService {
         return currentResponse;
     }
 
+    //TODO BOOK으로 반환하도록 수정(캐싱되어있는 북을 즐겨찾기에서도 써야하기떄문에 book형태로반환해야함)
     @Cacheable(cacheNames = "getBookInfo", key = "'book:isbn:' + #p2", cacheManager = "bookInfoCacheManager")
     public GetBookInfoResponse cachingBookInfo(String title, String author, String isbn, String cover, String description, String categoryName, String publisher, String publishedDate) {
         return GetBookInfoResponse.of(categoryName, cover, title, author, false, publisher, publishedDate, isbn, description);

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/controller/FavoriteController.java
@@ -1,13 +1,12 @@
 package com.example.bookjourneybackend.domain.favorite.controller;
 
+import com.example.bookjourneybackend.domain.favorite.domain.dto.response.PostFavoriteAddResponse;
 import com.example.bookjourneybackend.domain.favorite.service.FavoriteService;
+import com.example.bookjourneybackend.global.annotation.LoginUserId;
 import com.example.bookjourneybackend.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -17,8 +16,9 @@ public class FavoriteController {
 
     private final FavoriteService favoriteService;
 
-    @GetMapping("/{isbn}")
-    public BaseResponse<> favoriteAdd(@PathVariable) {
-
+    @PostMapping("/{isbn}")
+    public BaseResponse<PostFavoriteAddResponse> addFavorite(@PathVariable("isbn") final String isbn, @LoginUserId final Long userId) {
+        log.info("[FavoriteController.addFavorite]");
+        return BaseResponse.ok(favoriteService.addFavorite(isbn,userId));
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/controller/FavoriteController.java
@@ -1,4 +1,24 @@
 package com.example.bookjourneybackend.domain.favorite.controller;
 
+import com.example.bookjourneybackend.domain.favorite.service.FavoriteService;
+import com.example.bookjourneybackend.global.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/favorites")
+@RequiredArgsConstructor
 public class FavoriteController {
+
+    private final FavoriteService favoriteService;
+
+    @GetMapping("/{isbn}")
+    public BaseResponse<> favoriteAdd(@PathVariable) {
+
+    }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/dto/response/PostFavoriteAddResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/dto/response/PostFavoriteAddResponse.java
@@ -1,0 +1,24 @@
+package com.example.bookjourneybackend.domain.favorite.domain.dto.response;
+
+import com.example.bookjourneybackend.domain.recentSearch.domain.dto.response.RecentSearchInfo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = PRIVATE)
+public class PostFavoriteAddResponse {
+
+    private Long bookId;
+    private boolean favorite;
+
+    public static PostFavoriteAddResponse of(Long bookId, boolean favorite) {
+        return new PostFavoriteAddResponse(bookId, favorite);
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/repository/FavoriteRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/repository/FavoriteRepository.java
@@ -14,4 +14,9 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
     @Query("SELECT COUNT(f) > 0 FROM Favorite f WHERE f.user.userId = :userId AND f.book = :book AND f.status = 'active'")
     boolean existsActiveFavoriteByUserIdAndBook(@Param("userId") Long userId, @Param("book") Book book);
+
+    @Query("SELECT COUNT(f) > 0 FROM Favorite f WHERE f.user.userId = :userId AND f.book.isbn = :isbn")
+    boolean existsFavoriteByUserIdAndIsbn(@Param("userId") Long userId, @Param("isbn") String isbn);
+
+
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
@@ -1,4 +1,87 @@
 package com.example.bookjourneybackend.domain.favorite.service;
 
+import com.example.bookjourneybackend.domain.book.domain.Book;
+import com.example.bookjourneybackend.domain.book.domain.GenreType;
+import com.example.bookjourneybackend.domain.book.domain.repository.BookRepository;
+import com.example.bookjourneybackend.domain.book.dto.response.GetBookInfoResponse;
+import com.example.bookjourneybackend.domain.book.service.BookCacheService;
+import com.example.bookjourneybackend.domain.favorite.domain.Favorite;
+import com.example.bookjourneybackend.domain.favorite.domain.dto.response.PostFavoriteAddResponse;
+import com.example.bookjourneybackend.domain.favorite.domain.repository.FavoriteRepository;
+import com.example.bookjourneybackend.domain.user.domain.User;
+import com.example.bookjourneybackend.domain.user.domain.repository.UserRepository;
+import com.example.bookjourneybackend.global.exception.GlobalException;
+import com.example.bookjourneybackend.global.util.DateUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_BOOK;
+import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_USER;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
 public class FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+    private final UserRepository userRepository;
+    private final BookRepository bookRepository;
+    private final BookCacheService bookCacheService;
+    private final DateUtil dateUtil;
+
+    /**
+     * isbn에 해당하는 책을 즐겨찾기에 추가
+     * 1. DB에 존재하면 DB에 존재하는 책을 바로 즐겨찾기 테이블에 추가
+     * 2. 존재하지 않는 다면 캐시저장소에서 정보 찾아와서 DB저장후 즐겨찾기 테이블에 추가
+     * @param isbn,userId
+     * @return PostFavoriteAddResponse
+     */
+    public PostFavoriteAddResponse addFavorite(String isbn, Long userId) {
+        log.info("[FavoriteService.addFavorite]");
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
+
+
+        //DB에 책 저장확인 없으면 캐시 저장소에서 확인
+        Book findBook = bookRepository.findByIsbn(isbn)
+                .orElseGet(() -> {
+                    //TODO bookCacheService.checkBookInfo retrun 형태 book으로 바뀌면 코드 리펙
+                    GetBookInfoResponse getBookInfoResponse = bookCacheService.checkBookInfo(isbn);
+
+                    if (getBookInfoResponse == null) {
+                        throw new GlobalException(CANNOT_FOUND_BOOK);
+                    }
+                    getBookInfoResponse.setFavorite(true);
+                    Book book = Book.builder()
+                            .isbn(isbn)
+                            .bookTitle(getBookInfoResponse.getBookTitle())
+                            .authorName(getBookInfoResponse.getAuthorName())
+                            .genre(GenreType.parsingGenreType(getBookInfoResponse.getGenre()))
+                            .publisher(getBookInfoResponse.getPublisher())
+                            .publishedDate(dateUtil.parseDateToLocalDateFromPublishedDateString(getBookInfoResponse.getPublishedDate()))
+                            .description(getBookInfoResponse.getDescription())
+                            .imageUrl(getBookInfoResponse.getImageUrl())
+                            .bestSeller(false)
+                            .pageCount(null)
+                            .build();
+
+                    //캐시 저장소에서 찾은 책 DB저장
+                    bookRepository.save(book);
+                    return book;
+                });
+
+        //즐겨찾기 추가
+        favoriteRepository.save(Favorite.builder()
+                .book(findBook)
+                .user(user)
+                .build());
+
+        return PostFavoriteAddResponse.of(findBook.getBookId(),true);
+    }
+
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
@@ -34,9 +34,8 @@ public class FavoriteService {
     /**
      * isbn에 해당하는 책을 즐겨찾기에 추가
      * 1. 해당책이 이미 즐겨찾기 되어있는 지 검사
-     * 1. DB에 존재하면 DB에 존재하는 책을 바로 즐겨찾기 테이블에 추가
-     * 2. 존재하지 않는 다면 캐시저장소에서 정보 찾아와서 DB저장후 즐겨찾기 테이블에 추가
-     * 3.
+     * 2. DB에 존재하면 DB에 존재하는 책을 바로 즐겨찾기 테이블에 추가
+     * 3. 존재하지 않는 다면 캐시저장소에서 정보 찾아와서 DB저장후 즐겨찾기 테이블에 추가
      * @param isbn,userId
      * @return PostFavoriteAddResponse
      */

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -91,7 +91,12 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
      * 10000 : recentSearch 관련
      */
     CANNOT_FOUND_RECENT_SEARCH(10000,BAD_REQUEST, "최근검색어를 찾을 수 없습니다."),
-    CANNOT_DELETE_RECENT_SEARCH(10001,BAD_REQUEST, "최근검색어를 삭제 할 수 없습니다.");
+    CANNOT_DELETE_RECENT_SEARCH(10001,BAD_REQUEST, "최근검색어를 삭제 할 수 없습니다."),
+
+    /**
+     * 11000 : recentSearch 관련
+     */
+    CANNOT_FAVORITE(11000,BAD_REQUEST, "이미 즐겨찾기 한 책입니다.");
 
     private final int code;
     private final HttpStatus status;


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #103 

## 📝작업 내용

-  즐겨찾기 추가 기능을 구현했습니다.
-  즐겨찾기를 추가할때 해당책이 이미 즐겨찾기 된책인지 검사합니다.
- db에 해당 책이 존재하는지 확인하고 존재한다면 바로 즐겨찾기 테이블이 업데이트됩니다.
- 존재하지 않는다면 `bookCacheService.checkBookInfo(isbn)`  를 사용해서 캐시 저장소에 저장되어있는 책정보로 책을 db에 저장한 후, 즐겨찾기 테이블을 업데이트합니다.
- 현재 `bookCacheService.checkBookInfo(isbn)`의 반환값이 `GetBookInfoResponse`이라 코드가 중복되는 부분이 많습니다. 추후에 `Book`을 반환하도록 리펙토링 한 후에 즐겨찾기 추가 기능 로직도 리펙토링하면 될 것같습니다!

### 스크린샷 (선택)
<img width="324" alt="image" src="https://github.com/user-attachments/assets/55f48d08-8599-4e4a-851c-40aa53061bb3" />

이미 즐겨찾기한 책을 추가하려는 경우 예외처리가 됩니다.

![image](https://github.com/user-attachments/assets/689c3294-dd5f-4f18-bee2-66cc5d055b5e)
![image](https://github.com/user-attachments/assets/424acb6a-6479-497a-bf28-8caaef21f8c0)

DB에도 존재하지않고, 캐시 저장소에도 저장되어있지 않은 책을 즐겨찾기에 추가할 경우 알라딘 api를 전송 후 책정보를 받아와 db에 저장합니다.

![image](https://github.com/user-attachments/assets/01f1acb6-2c7d-4c32-92fd-7e0a6d5413c3)
![image](https://github.com/user-attachments/assets/e4c90e7e-1dbb-4f34-aa61-8689b5e07295)

DB에 존재하진 않지만,  캐시 저장소에있는 책을 즐겨찾기에 추가할 경우 캐시 저장소에서 책을 찾아서 즐겨찾기에 추가합니다.

<img width="313" alt="image" src="https://github.com/user-attachments/assets/05b2f70a-5261-4975-bf6c-d00946c8d7b2" />

DB에 존재한다면 바로 찾아서 즐겨찾기에 추가합니다.
