### PR TITLE
[FEAT] 독서기록장(다 안 읽었어요) 조회 api 구현

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/room/controller/RoomArchiveController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/controller/RoomArchiveController.java
@@ -1,0 +1,28 @@
+package com.example.bookjourneybackend.domain.room.controller;
+
+import com.example.bookjourneybackend.domain.room.dto.response.GetRoomArchiveResponse;
+import com.example.bookjourneybackend.domain.room.service.RoomArchiveService;
+import com.example.bookjourneybackend.global.annotation.LoginUserId;
+import com.example.bookjourneybackend.global.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/rooms/archive")
+public class RoomArchiveController {
+
+    private final RoomArchiveService roomArchiveService;
+
+    @GetMapping
+    public BaseResponse<GetRoomArchiveResponse> viewCompletedRooms(@LoginUserId final Long userId,
+                                                                   @RequestParam(required = false) final String date
+    ) {
+        return BaseResponse.ok(roomArchiveService.viewInCompletedRooms(userId, date));
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/room/controller/RoomArchiveController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/controller/RoomArchiveController.java
@@ -21,7 +21,7 @@ public class RoomArchiveController {
 
     @GetMapping
     public BaseResponse<GetRoomArchiveResponse> viewCompletedRooms(@LoginUserId final Long userId,
-                                                                   @RequestParam(required = false) final String date
+                                                                   @RequestParam final String date
     ) {
         return BaseResponse.ok(roomArchiveService.viewInCompletedRooms(userId, date));
     }

--- a/src/main/java/com/example/bookjourneybackend/domain/room/controller/RoomArchiveController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/controller/RoomArchiveController.java
@@ -20,9 +20,11 @@ public class RoomArchiveController {
     private final RoomArchiveService roomArchiveService;
 
     @GetMapping
-    public BaseResponse<GetRoomArchiveResponse> viewCompletedRooms(@LoginUserId final Long userId,
-                                                                   @RequestParam final String date
-    ) {
-        return BaseResponse.ok(roomArchiveService.viewInCompletedRooms(userId, date));
+    public BaseResponse<GetRoomArchiveResponse> viewCompletedRooms(
+            @LoginUserId final Long userId,
+            @RequestParam(required = false) final Integer month,
+            @RequestParam(required = false) final Integer year)
+    {
+        return BaseResponse.ok(roomArchiveService.viewInCompletedRooms(userId, month, year));
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/room/domain/Room.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/domain/Room.java
@@ -80,6 +80,7 @@ public class Room extends BaseEntity {
         return Room.builder()
                 .roomType(RoomType.ALONE)
                 .book(book)
+                .startDate(LocalDate.now())
                 .roomPercentage(0.0)
                 .recruitCount(1)
                 .build();

--- a/src/main/java/com/example/bookjourneybackend/domain/room/dto/response/GetRoomArchiveResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/dto/response/GetRoomArchiveResponse.java
@@ -1,0 +1,21 @@
+package com.example.bookjourneybackend.domain.room.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class GetRoomArchiveResponse {
+
+    private List<RecordInfo> recordList;
+
+    public GetRoomArchiveResponse(List<RecordInfo> recordList) {
+        this.recordList = recordList;
+    }
+
+    public static GetRoomArchiveResponse of(List<RecordInfo> recordList) {
+        return new GetRoomArchiveResponse(recordList);
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomArchiveService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomArchiveService.java
@@ -32,13 +32,21 @@ public class RoomArchiveService {
      * 해당 사용자의 status가 'INACTIVE'인 UserRoom 중에서 queryParam으로 넘어온 날짜에 겹치는 날을 필터링하여 조회
      * 정렬은 inActivatedAt 내림차순으로 정렬
      */
-    public GetRoomArchiveResponse viewInCompletedRooms(Long userId, String date) {
+    public GetRoomArchiveResponse viewInCompletedRooms(Long userId, Integer month, Integer year) {
         log.info("------------------------[RoomArchiveService.viewCompletedRooms]------------------------");
 
-        LocalDate localDate = dateUtil.parseDate(date);
+        List<UserRoom> togetherArchiveList;
+        List<UserRoom> aloneArchiveList;
 
-        List<UserRoom> togetherArchiveList = userRoomRepository.findInActiveTogetherRoomsByUserIdAndDate(userId, localDate);
-        List<UserRoom> aloneArchiveList = userRoomRepository.findInActiveAloneRoomsByUserIdAndDate(userId, localDate);
+        if (year == null) {
+            // year가 null이면 이번달과 겹치는 모든 방을 조회
+            year = LocalDate.now().getYear();
+            month = LocalDate.now().getMonthValue();
+        }
+
+        //month가 null일 경우에는 해당 년도의 모든 방을 조회
+        togetherArchiveList = userRoomRepository.findInActiveTogetherRoomsByUserIdAndDate(userId, year, month);
+        aloneArchiveList = userRoomRepository.findInActiveAloneRoomsByUserIdAndDate(userId, year, month);
 
         return new GetRoomArchiveResponse(combineAndParseToRecordInfo(togetherArchiveList, aloneArchiveList));
     }

--- a/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomArchiveService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomArchiveService.java
@@ -1,0 +1,71 @@
+package com.example.bookjourneybackend.domain.room.service;
+
+import com.example.bookjourneybackend.domain.book.domain.Book;
+import com.example.bookjourneybackend.domain.room.domain.Room;
+import com.example.bookjourneybackend.domain.room.domain.repository.RoomRepository;
+import com.example.bookjourneybackend.domain.room.dto.response.GetRoomArchiveResponse;
+import com.example.bookjourneybackend.domain.room.dto.response.RecordInfo;
+import com.example.bookjourneybackend.domain.userRoom.domain.UserRoom;
+import com.example.bookjourneybackend.domain.userRoom.domain.repository.UserRoomRepository;
+import com.example.bookjourneybackend.global.util.DateUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RoomArchiveService {
+
+    private final RoomRepository roomRepository;
+    private final UserRoomRepository userRoomRepository;
+    private final DateUtil dateUtil;
+
+    /**
+     * <독서기록장 다 안읽었어요>
+     * 해당 사용자의 status가 'INACTIVE'인 UserRoom 중에서 queryParam으로 넘어온 날짜에 겹치는 날을 필터링하여 조회
+     * 정렬은 inActivatedAt 내림차순으로 정렬
+     */
+    public GetRoomArchiveResponse viewInCompletedRooms(Long userId, String date) {
+        log.info("------------------------[RoomArchiveService.viewCompletedRooms]------------------------");
+
+        LocalDate localDate = dateUtil.parseDate(date);
+
+        List<UserRoom> togetherArchiveList = userRoomRepository.findInActiveTogetherRoomsByUserIdAndDate(userId, localDate);
+        List<UserRoom> aloneArchiveList = userRoomRepository.findInActiveAloneRoomsByUserIdAndDate(userId, localDate);
+
+        return new GetRoomArchiveResponse(combineAndParseToRecordInfo(togetherArchiveList, aloneArchiveList));
+    }
+
+    //DB에서 찾은 같이읽기와 혼자읽기 방을 InActivatedAt 내림차순으로 정렬하여 RecordInfo의 리스트로 파싱
+    private List<RecordInfo> combineAndParseToRecordInfo(List<UserRoom> togetherArchiveList, List<UserRoom> aloneArchiveList) {
+        List<UserRoom> combinedList = new ArrayList<>();
+        combinedList.addAll(togetherArchiveList);
+        combinedList.addAll(aloneArchiveList);
+
+        combinedList.sort(Comparator.comparing(UserRoom::getInActivatedAt).reversed());
+
+        return combinedList.stream()
+                .map(userRoom -> {
+                    Room room = userRoom.getRoom();
+                    Book book = room.getBook();
+                    return RecordInfo
+                            .builder()
+                            .roomId(room.getRoomId())
+                            .imageUrl(book.getImageUrl())
+                            .roomType(room.getRoomType().getRoomType())
+                            .bookTitle(book.getBookTitle())
+                            .modifiedAt(dateUtil.calculateLastActivityTime(room.getRecords()))
+                            .authorName(book.getAuthorName())
+                            .userPercentage(userRoom.getUserPercentage())
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
@@ -337,6 +337,7 @@ public class RoomService {
         UserRoom userRoom = getUserRoom(roomId, userId);
 
         userRoom.setStatus(EntityStatus.INACTIVE);
+        userRoom.setInActivatedAt(dateUtil.getCurrentTime());
         userRoomRepository.save(userRoom);
 
         return null;

--- a/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/UserRoom.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/UserRoom.java
@@ -10,6 +10,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 import static com.example.bookjourneybackend.global.entity.EntityStatus.DELETED;
 
 @Entity
@@ -36,6 +38,9 @@ public class UserRoom extends BaseEntity {
 
     @Column(nullable = false)
     private Integer currentPage;
+
+    @Setter
+    private LocalDateTime inActivatedAt;
 
     // Room의 관계 추가
     @Setter

--- a/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
@@ -35,18 +35,18 @@ public interface UserRoomRepository extends JpaRepository<UserRoom, Long> {
 
     List<UserRoom> findAllByRoom(Room room);
 
-    @Query("SELECT ur FROM UserRoom ur " +
+   @Query("SELECT ur FROM UserRoom ur " +
             "JOIN FETCH ur.room r " +
             "WHERE ur.user.userId = :userId AND ur.status = 'INACTIVE' " +
-            "AND (MONTH(r.startDate) <= MONTH(:localDate) AND YEAR(r.startDate) <= YEAR(:localDate) " +
-            "OR MONTH(r.progressEndDate) >= MONTH(:localDate) AND YEAR(r.progressEndDate) >= YEAR(:localDate)) " +
+            "AND ((:month IS NULL OR MONTH(r.startDate) <= :month) AND YEAR(r.startDate) <= :year " +
+            "OR (:month IS NULL OR MONTH(r.progressEndDate) >= :month) AND YEAR(r.progressEndDate) >= :year) " +
             "AND r.roomType = 'TOGETHER'")
-    List<UserRoom> findInActiveTogetherRoomsByUserIdAndDate(@Param("userId") Long userId, @Param("localDate") LocalDate localDate);
+   List<UserRoom> findInActiveTogetherRoomsByUserIdAndDate(@Param("userId") Long userId, @Param("year") Integer year, @Param("month") Integer month);
 
     @Query("SELECT ur FROM UserRoom ur " +
             "JOIN FETCH ur.room r " +
             "WHERE ur.user.userId = :userId AND ur.status = 'INACTIVE' " +
-            "AND MONTH(r.startDate) <= MONTH(:localDate) " +
+            "AND ((:month IS NULL OR MONTH(r.startDate) <= :month) AND YEAR(r.startDate) <= :year) " +
             "AND r.roomType = 'ALONE'")
-    List<UserRoom> findInActiveAloneRoomsByUserIdAndDate(Long userId, LocalDate localDate);
+    List<UserRoom> findInActiveAloneRoomsByUserIdAndDate(@Param("userId") Long userId, @Param("year") Integer year, @Param("month") Integer month);
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,4 +34,19 @@ public interface UserRoomRepository extends JpaRepository<UserRoom, Long> {
     boolean existsByRoomAndUser(Room room, User user);
 
     List<UserRoom> findAllByRoom(Room room);
+
+    @Query("SELECT ur FROM UserRoom ur " +
+            "JOIN FETCH ur.room r " +
+            "WHERE ur.user.userId = :userId AND ur.status = 'INACTIVE' " +
+            "AND (MONTH(r.startDate) <= MONTH(:localDate) AND YEAR(r.startDate) <= YEAR(:localDate) " +
+            "OR MONTH(r.progressEndDate) >= MONTH(:localDate) AND YEAR(r.progressEndDate) >= YEAR(:localDate)) " +
+            "AND r.roomType = 'TOGETHER'")
+    List<UserRoom> findInActiveTogetherRoomsByUserIdAndDate(@Param("userId") Long userId, @Param("localDate") LocalDate localDate);
+
+    @Query("SELECT ur FROM UserRoom ur " +
+            "JOIN FETCH ur.room r " +
+            "WHERE ur.user.userId = :userId AND ur.status = 'INACTIVE' " +
+            "AND MONTH(r.startDate) <= MONTH(:localDate) " +
+            "AND r.roomType = 'ALONE'")
+    List<UserRoom> findInActiveAloneRoomsByUserIdAndDate(Long userId, LocalDate localDate);
 }

--- a/src/main/java/com/example/bookjourneybackend/global/util/DateUtil.java
+++ b/src/main/java/com/example/bookjourneybackend/global/util/DateUtil.java
@@ -22,6 +22,11 @@ public class DateUtil {
         return date != null ? LocalDate.parse(date) : null;
     }
 
+    //현재 시각을 LocalDateTime으로 반환
+    public LocalDateTime getCurrentTime() {
+        return LocalDateTime.now();
+    }
+
     //기록들 중 마지막 활동 시간 계산 -> 가장 최근에 수정된 기록의 시간을 반환 (ex. 1분 전, 1시간 전, 1일 전)
     public String calculateLastActivityTime(List<Record> records) {
         return records.stream()


### PR DESCRIPTION
## #️⃣연관된 이슈

- closed #102 

## 📝작업 내용

- 기본적으로 UserRoom의 status가 INACTIVE인 것만 조회합니다.
- 같이읽기의 경우, queryParam으로 넘어온 날짜(날짜는 해당 월의 1일 기준으로 넘어오도록 정의)의 월이 startDate와 progressEnddate의  월 사이에 있는 것만 조회합니다.
- 혼자읽기의 경우, queryParam으로 넘어온 날짜의 월이 startDate의 월보다 크거나 같은 경우만 조회합니다. (startDate ~ 현재까지 조회해야 하므로)
- 조회한 모든 UserRoom을 inactivatedAt을 기준으로 내림차순으로 정렬하여 dto로 파싱하여 반환합니다.
- 추가적으로 year가 null로 왔을때는 현재 year와 month를 기준으로 조회하고 month만 null일 경우는 year의 전체를 조회합니다!

### 스크린샷 (선택)

**year와 month가 둘다 제공되었을 경우**
<img width="847" alt="스크린샷 2025-02-03 오후 6 25 41" src="https://github.com/user-attachments/assets/26bcc386-2da1-4093-9454-109262ef1695" />

**month가 제공되지 않을 경우**
<img width="847" alt="스크린샷 2025-02-03 오후 6 25 36" src="https://github.com/user-attachments/assets/d5e86316-2c59-496e-ae09-ea95a060863c" />

**year와 month가 둘다 제공되지 않을 경우**
<img width="847" alt="스크린샷 2025-02-03 오후 6 25 31" src="https://github.com/user-attachments/assets/234f86e0-2697-4225-bdce-fd6cc34ee366" />

## 💬리뷰 요구사항(선택)

> 저번 pr에서 이야기 한대로 recordList가 비어있을 때의 예외처리는 따로 해주지 않았습니다!


### ++추가 수정사항
1. 진행 중인 기록 삭제에서 방을 INACTIVE로 변경할때 UserRoom의 inActivatedAt을 현재로 업데이트
2. 혼자읽기 방 생성시 startDate의 현재 날짜를 넣어줌
