### PR TITLE
[FEAT] 독서기록장 (다 읽었어요) api 구현

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/room/controller/RoomArchiveController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/controller/RoomArchiveController.java
@@ -11,6 +11,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.example.bookjourneybackend.global.entity.EntityStatus.EXPIRED;
+import static com.example.bookjourneybackend.global.entity.EntityStatus.INACTIVE;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -20,11 +23,19 @@ public class RoomArchiveController {
     private final RoomArchiveService roomArchiveService;
 
     @GetMapping
+    public BaseResponse<GetRoomArchiveResponse> viewInCompletedRooms(
+            @LoginUserId final Long userId,
+            @RequestParam(required = false) final Integer month,
+            @RequestParam(required = false) final Integer year) {
+        return BaseResponse.ok(roomArchiveService.viewArchiveRooms(userId, month, year, INACTIVE));
+    }
+
+    @GetMapping("/completed")
     public BaseResponse<GetRoomArchiveResponse> viewCompletedRooms(
             @LoginUserId final Long userId,
             @RequestParam(required = false) final Integer month,
-            @RequestParam(required = false) final Integer year)
-    {
-        return BaseResponse.ok(roomArchiveService.viewInCompletedRooms(userId, month, year));
+            @RequestParam(required = false) final Integer year) {
+        return BaseResponse.ok(roomArchiveService.viewArchiveRooms(userId, month, year, EXPIRED));
     }
+
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/room/dto/request/PostRoomCreateRequest.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/dto/request/PostRoomCreateRequest.java
@@ -29,7 +29,7 @@ public class PostRoomCreateRequest {
 
     private Integer password;
 
-    @NotBlank(message = "ISBN cannot be blank.")
+    @NotBlank(message = "ISBN은 방 생성시 필수 입력값입니다..")
     @Pattern(regexp = "\\d{10,13}", message = "ISBN은 10이나 13자리로 이루어집니다.")
     private String isbn;
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomArchiveService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomArchiveService.java
@@ -7,6 +7,7 @@ import com.example.bookjourneybackend.domain.room.dto.response.GetRoomArchiveRes
 import com.example.bookjourneybackend.domain.room.dto.response.RecordInfo;
 import com.example.bookjourneybackend.domain.userRoom.domain.UserRoom;
 import com.example.bookjourneybackend.domain.userRoom.domain.repository.UserRoomRepository;
+import com.example.bookjourneybackend.global.entity.EntityStatus;
 import com.example.bookjourneybackend.global.util.DateUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +19,9 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.example.bookjourneybackend.global.entity.EntityStatus.EXPIRED;
+import static com.example.bookjourneybackend.global.entity.EntityStatus.INACTIVE;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -28,15 +32,13 @@ public class RoomArchiveService {
     private final DateUtil dateUtil;
 
     /**
-     * <독서기록장 다 안읽었어요>
-     * 해당 사용자의 status가 'INACTIVE'인 UserRoom 중에서 queryParam으로 넘어온 날짜에 겹치는 날을 필터링하여 조회
+     * status=INACTIVE => <독서기록장 다 안읽었어요>
+     * status=EXPIRED => <독서기록장 다 읽었어요>
+     * 해당 사용자의 status에 따른 UserRoom 중에서 queryParam으로 넘어온 날짜에 겹치는 날을 필터링하여 조회
      * 정렬은 inActivatedAt 내림차순으로 정렬
      */
-    public GetRoomArchiveResponse viewInCompletedRooms(Long userId, Integer month, Integer year) {
-        log.info("------------------------[RoomArchiveService.viewCompletedRooms]------------------------");
-
-        List<UserRoom> togetherArchiveList;
-        List<UserRoom> aloneArchiveList;
+    public GetRoomArchiveResponse viewArchiveRooms(Long userId, Integer month, Integer year, EntityStatus status) {
+        log.info("------------------------[RoomArchiveService.viewArchiveRooms]------------------------");
 
         if (year == null) {
             // year가 null이면 이번달과 겹치는 모든 방을 조회
@@ -45,19 +47,32 @@ public class RoomArchiveService {
         }
 
         //month가 null일 경우에는 해당 년도의 모든 방을 조회
-        togetherArchiveList = userRoomRepository.findInActiveTogetherRoomsByUserIdAndDate(userId, year, month);
-        aloneArchiveList = userRoomRepository.findInActiveAloneRoomsByUserIdAndDate(userId, year, month);
+        List<UserRoom> togetherArchiveList = userRoomRepository.findInActiveTogetherRoomsByUserIdAndDate(userId, year, month, status);
+        List<UserRoom> aloneArchiveList = userRoomRepository.findInActiveAloneRoomsByUserIdAndDate(userId, year, month, status);
 
-        return new GetRoomArchiveResponse(combineAndParseToRecordInfo(togetherArchiveList, aloneArchiveList));
+        return new GetRoomArchiveResponse(combineAndParseToRecordInfo(togetherArchiveList, aloneArchiveList, status));
     }
 
     //DB에서 찾은 같이읽기와 혼자읽기 방을 InActivatedAt 내림차순으로 정렬하여 RecordInfo의 리스트로 파싱
-    private List<RecordInfo> combineAndParseToRecordInfo(List<UserRoom> togetherArchiveList, List<UserRoom> aloneArchiveList) {
+    private List<RecordInfo> combineAndParseToRecordInfo(List<UserRoom> togetherArchiveList, List<UserRoom> aloneArchiveList, EntityStatus status) {
         List<UserRoom> combinedList = new ArrayList<>();
         combinedList.addAll(togetherArchiveList);
         combinedList.addAll(aloneArchiveList);
 
-        combinedList.sort(Comparator.comparing(UserRoom::getInActivatedAt).reversed());
+        if (status == INACTIVE) {
+            combinedList.sort(Comparator.comparing(UserRoom::getInActivatedAt).reversed());
+        }
+        if(status == EXPIRED) {
+            //혼자읽기책과 같이읽기방을 구분하지 않고, 기간의 마지막일 날짜가 가장 오래 전인 책 및 방이 가장 상단에 위치하도록 정렬
+            //기간의 마지막일이 같으면?
+            //혼자읽기책과 같이읽기 방 중에서는 혼자읽기 책이 위에 배치되고 -> 제외
+            //시작일을 기준으로, 시작일이 더 예전일 때 위에 배치
+            //(혼자읽기 책의 경우, 시작일 = 유저가 혼자읽기 버튼을 누른 시점
+            //같이읽기 방의 경우, 시작일 = 방기간의 시작일)
+            combinedList.sort(Comparator.comparing(UserRoom::getRoom , Comparator.comparing(Room::getProgressEndDate, Comparator.nullsLast(Comparator.reverseOrder())))
+                    .thenComparing(UserRoom::getRoom, Comparator.comparing(Room::getStartDate, Comparator.naturalOrder())));
+        }
+
 
         return combinedList.stream()
                 .map(userRoom -> {

--- a/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
@@ -270,6 +270,8 @@ public class RoomService {
         if (request.getRecruitCount() == 1) {
             room = Room.makeReadAloneRoom(book);
         } else {
+            validatedRoomCreateRequest(request);
+
             LocalDate startDate = dateUtil.parseDateToLocalDateString(request.getProgressStartDate());
             LocalDate progressEndDate = dateUtil.parseDateToLocalDateString(request.getProgressEndDate());
             room = Room.makeReadTogetherRoom(
@@ -279,6 +281,18 @@ public class RoomService {
         }
         room.addUserRoom(userRoom);
         return room;
+    }
+
+    private void validatedRoomCreateRequest(PostRoomCreateRequest request) {
+        // 같이읽기 방에서 startDate, progressEndDate가 null일 경우 예외 처리
+        // isPublic이 false이면 password가 null일 경우 예외 처리
+        if (request.getProgressStartDate() == null || request.getProgressEndDate() == null) {
+            throw new GlobalException(CANNOT_NULL_DATE);
+        }
+
+        if (!request.isPublic() && request.getPassword() == null) {
+            throw new GlobalException(CANNOT_NULL_PASSWORD);
+        }
     }
 
     /**

--- a/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
@@ -37,16 +37,17 @@ public interface UserRoomRepository extends JpaRepository<UserRoom, Long> {
 
    @Query("SELECT ur FROM UserRoom ur " +
             "JOIN FETCH ur.room r " +
-            "WHERE ur.user.userId = :userId AND ur.status = 'INACTIVE' " +
+            "WHERE ur.user.userId = :userId AND ur.status = :status " +
             "AND ((:month IS NULL OR MONTH(r.startDate) <= :month) AND YEAR(r.startDate) <= :year " +
             "OR (:month IS NULL OR MONTH(r.progressEndDate) >= :month) AND YEAR(r.progressEndDate) >= :year) " +
             "AND r.roomType = 'TOGETHER'")
-   List<UserRoom> findInActiveTogetherRoomsByUserIdAndDate(@Param("userId") Long userId, @Param("year") Integer year, @Param("month") Integer month);
+   List<UserRoom> findInActiveTogetherRoomsByUserIdAndDate(@Param("userId") Long userId, @Param("year") Integer year, @Param("month") Integer month, @Param("status") EntityStatus status);
 
     @Query("SELECT ur FROM UserRoom ur " +
             "JOIN FETCH ur.room r " +
-            "WHERE ur.user.userId = :userId AND ur.status = 'INACTIVE' " +
+            "WHERE ur.user.userId = :userId AND ur.status = :status " +
             "AND ((:month IS NULL OR MONTH(r.startDate) <= :month) AND YEAR(r.startDate) <= :year) " +
+            "AND (r.progressEndDate IS NULL OR (MONTH(r.progressEndDate) >= :month AND YEAR(r.progressEndDate) >= :year)) " +
             "AND r.roomType = 'ALONE'")
-    List<UserRoom> findInActiveAloneRoomsByUserIdAndDate(@Param("userId") Long userId, @Param("year") Integer year, @Param("month") Integer month);
+    List<UserRoom> findInActiveAloneRoomsByUserIdAndDate(@Param("userId") Long userId, @Param("year") Integer year, @Param("month") Integer month, @Param("status") EntityStatus status);
 }

--- a/src/main/java/com/example/bookjourneybackend/global/config/initData/RecentSearchInitializer.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/initData/RecentSearchInitializer.java
@@ -25,19 +25,22 @@ public class RecentSearchInitializer {
     public void initializeRecentSearches() {
         List<User> users = userRepository.findAll(); // User 리스트 로드
 
-        for (int i = 0; i < users.size(); i++) {
-            User user = users.get(i); // 특정 User 가져오기
+        for (int j = 0; j < 5; j++) {
+            for (int i = 0; i < users.size(); i++) {
+                User user = users.get(i); // 특정 User 가져오기
 
-            RecentSearch recentSearch = RecentSearch.builder()
-                    .user(user)
-                    .recentSearch("Search query " + i)
-                    .build();
+                RecentSearch recentSearch = RecentSearch.builder()
+                        .user(user)
+                        .recentSearch("Search query " + i)
+                        .build();
 
-            // 연관관계 설정
-            user.addRecentSearch(recentSearch);
+                // 연관관계 설정
+                user.addRecentSearch(recentSearch);
 
-            // RecentSearch 저장
-            recentSearchRepository.save(recentSearch);
+                // RecentSearch 저장
+                recentSearchRepository.save(recentSearch);
+            }
         }
+
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/global/config/initData/UserRoomInitializer.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/initData/UserRoomInitializer.java
@@ -7,10 +7,13 @@ import com.example.bookjourneybackend.domain.user.domain.repository.UserReposito
 import com.example.bookjourneybackend.domain.userRoom.domain.UserRole;
 import com.example.bookjourneybackend.domain.userRoom.domain.UserRoom;
 import com.example.bookjourneybackend.domain.userRoom.domain.repository.UserRoomRepository;
+import com.example.bookjourneybackend.global.entity.EntityStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import jakarta.transaction.Transactional;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Random;
 
@@ -45,6 +48,10 @@ public class UserRoomInitializer {
                     .userPercentage(randomPercentage)
                     .currentPage(1)
                     .build();
+
+            EntityStatus[] statuses = EntityStatus.values();
+            userRoom.setStatus(statuses[random.nextInt(statuses.length)]); // 랜덤한 상태
+            userRoom.setInActivatedAt(LocalDateTime.now());
 
             room.addUserRoom(userRoom);
             user.addUserRoom(userRoom);

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -75,6 +75,9 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
 
     CANNOT_FOUND_RECRUITMENT_ROOM(8008, BAD_REQUEST, "모집 중인 방을 찾을 수 없습니다."),
 
+    CANNOT_NULL_DATE(8009, BAD_REQUEST, "같이읽기 방 생성시, 기간은 필수 입력값입니다."),
+    CANNOT_NULL_PASSWORD(8010, BAD_REQUEST, "비공개 방 생성시, 비밀번호는 필수 입력값입니다."),
+
     /**
      * 9000 : record 관련
      */


### PR DESCRIPTION
## #️⃣연관된 이슈

- closed #104 

## 📝작업 내용

> status가 EXPIRED인 UserRoom 중에서 파라미터로 넘어온 기간 안에 존재하는 Room들을 조회 

정렬조건은 다음과 같습니다.
1. progressEndDate 기준으로 내림차순
2. startDate 기준으로 오름차순

이외의 파리미터들의 null처리는 다 안읽었어요 api와 동일합니다!
### 스크린샷 (선택)
<img width="847" alt="스크린샷 2025-02-03 오후 7 36 55" src="https://github.com/user-attachments/assets/b89c3e6c-ed2d-4d64-af1a-bfe30e55114b" />


## 💬리뷰 요구사항(선택)

> 주혜님의 요청으로 RecetSearch의 더미데이터의 양을 증가시켰습니다.
> 추가적으로 UserRoom의 status를 랜덤하게 배정하고, atActivatedTime의 값도 주입하도록 수정하였습니다.

++ 추가적으로 방 생성시 null에 대한 예외처리 추가하였습니다!
