### PR TITLE
[FEAT] 즐겨찾기 선택 삭제 구현

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/auth/domain/dto/request/PostAuthAccessTokenReissueRequest.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/auth/domain/dto/request/PostAuthAccessTokenReissueRequest.java
@@ -1,5 +1,6 @@
 package com.example.bookjourneybackend.domain.auth.domain.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class PostAuthAccessTokenReissueRequest {
 
     //엑세스 토큰 재발급 Request
-    @NotNull(message = "리프레쉬 토큰 입력은 필수입니다")
+    @NotBlank(message = "리프레쉬 토큰 입력은 필수입니다")
     private String refreshToken;
 
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/controller/FavoriteController.java
@@ -28,4 +28,9 @@ public class FavoriteController {
         log.info("[FavoriteController.viewFavoriteList]");
         return BaseResponse.ok(favoriteService.showFavoriteList(userId));
     }
+
+//    @DeleteMapping("/favorites")
+//    public BaseResponse<> deleteFavorite(@RequestParam final String sort, @LoginUserId final Long userId) {
+//        log.info("[FavoriteController.deleteFavorite]");
+//    }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/controller/FavoriteController.java
@@ -1,10 +1,12 @@
 package com.example.bookjourneybackend.domain.favorite.controller;
 
+import com.example.bookjourneybackend.domain.favorite.domain.dto.request.DeleteFavoriteSelectedRequest;
 import com.example.bookjourneybackend.domain.favorite.domain.dto.response.GetFavoriteListResponse;
 import com.example.bookjourneybackend.domain.favorite.domain.dto.response.PostFavoriteAddResponse;
 import com.example.bookjourneybackend.domain.favorite.service.FavoriteService;
 import com.example.bookjourneybackend.global.annotation.LoginUserId;
 import com.example.bookjourneybackend.global.response.BaseResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -29,8 +31,10 @@ public class FavoriteController {
         return BaseResponse.ok(favoriteService.showFavoriteList(userId));
     }
 
-//    @DeleteMapping("/favorites")
-//    public BaseResponse<> deleteFavorite(@RequestParam final String sort, @LoginUserId final Long userId) {
-//        log.info("[FavoriteController.deleteFavorite]");
-//    }
+    @DeleteMapping
+    public BaseResponse<Void> deleteSelectedFavorite(@RequestBody final DeleteFavoriteSelectedRequest deleteFavoriteSelectedRequest,
+                                                     @LoginUserId final Long userId) {
+        log.info("[FavoriteController.deleteSelectedFavorite]");
+        return BaseResponse.ok(favoriteService.deleteSelectedFavorite(deleteFavoriteSelectedRequest,userId));
+    }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/dto/request/DeleteFavoriteSelectedRequest.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/dto/request/DeleteFavoriteSelectedRequest.java
@@ -21,7 +21,7 @@ public class DeleteFavoriteSelectedRequest {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor(access = PRIVATE)
-    public static class FavoriteInfo {
+    private static class FavoriteInfo {
 
         private Long favoriteId;
     }

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/dto/request/DeleteFavoriteSelectedRequest.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/dto/request/DeleteFavoriteSelectedRequest.java
@@ -22,8 +22,14 @@ public class DeleteFavoriteSelectedRequest {
     @NoArgsConstructor
     @AllArgsConstructor(access = PRIVATE)
     private static class FavoriteInfo {
-
         private Long favoriteId;
+
+    }
+
+    public List<Long> getFavoriteIds() {
+        return favoriteList.stream()
+                .map(FavoriteInfo::getFavoriteId)
+                .toList();
     }
 
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/dto/request/DeleteFavoriteSelectedRequest.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/dto/request/DeleteFavoriteSelectedRequest.java
@@ -1,0 +1,9 @@
+package com.example.bookjourneybackend.domain.favorite.domain.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DeleteFavoriteSelectedRequest {
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/dto/request/DeleteFavoriteSelectedRequest.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/dto/request/DeleteFavoriteSelectedRequest.java
@@ -1,9 +1,29 @@
 package com.example.bookjourneybackend.domain.favorite.domain.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
+import static lombok.AccessLevel.PRIVATE;
+
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor(access = PRIVATE)
 public class DeleteFavoriteSelectedRequest {
+
+    private List<FavoriteInfo> favoriteList;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor(access = PRIVATE)
+    public static class FavoriteInfo {
+
+        private Long favoriteId;
+    }
+
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
@@ -139,9 +139,7 @@ public class FavoriteService {
                 .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
 
         // 삭제할 favoriteId 리스트 추출
-        List<Long> favoriteIds = deleteFavoriteSelectedRequest.getFavoriteList().stream()
-                .map(DeleteFavoriteSelectedRequest.FavoriteInfo::getFavoriteId)
-                .toList();
+        List<Long> favoriteIds = deleteFavoriteSelectedRequest.getFavoriteIds();
 
         // 삭제할 즐겨찾기가 선택되지않음
         if (favoriteIds.isEmpty()) {

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
@@ -7,6 +7,7 @@ import com.example.bookjourneybackend.domain.book.dto.response.BookInfo;
 import com.example.bookjourneybackend.domain.book.dto.response.GetBookInfoResponse;
 import com.example.bookjourneybackend.domain.book.service.BookCacheService;
 import com.example.bookjourneybackend.domain.favorite.domain.Favorite;
+import com.example.bookjourneybackend.domain.favorite.domain.dto.request.DeleteFavoriteSelectedRequest;
 import com.example.bookjourneybackend.domain.favorite.domain.dto.response.GetFavoriteListResponse;
 import com.example.bookjourneybackend.domain.favorite.domain.dto.response.PostFavoriteAddResponse;
 import com.example.bookjourneybackend.domain.favorite.domain.repository.FavoriteRepository;
@@ -14,6 +15,8 @@ import com.example.bookjourneybackend.domain.user.domain.User;
 import com.example.bookjourneybackend.domain.user.domain.repository.UserRepository;
 import com.example.bookjourneybackend.global.exception.GlobalException;
 import com.example.bookjourneybackend.global.util.DateUtil;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -37,6 +40,8 @@ public class FavoriteService {
     private final BookRepository bookRepository;
     private final BookCacheService bookCacheService;
     private final DateUtil dateUtil;
+    @PersistenceContext
+    private final EntityManager entityManager;
 
     /**
      * isbn에 해당하는 책을 즐겨찾기에 추가
@@ -118,4 +123,47 @@ public class FavoriteService {
         return GetFavoriteListResponse.of(bookList);
     }
 
+    /**
+     * 해당 유저가 선택한 즐겨찾기 삭제
+     * 1.삭제할 즐겨찾기 선택되었는지 검증(리스트가 비어서 요청보내진건지 검증)
+     * 2.존재하는 즐겨찾기인지 검증
+     * 3.요청을 보낸 사용자가 등록한 즐겨찾기인지 검증
+     * 4.선택한 즐겨찾기 전체삭제
+     * @param deleteFavoriteSelectedRequest,userId
+     */
+    public Void deleteSelectedFavorite(DeleteFavoriteSelectedRequest deleteFavoriteSelectedRequest, Long userId) {
+        log.info("[FavoriteService.deleteSelectedFavorite]");
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
+
+        // 삭제할 favoriteId 리스트 추출
+        List<Long> favoriteIds = deleteFavoriteSelectedRequest.getFavoriteList().stream()
+                .map(DeleteFavoriteSelectedRequest.FavoriteInfo::getFavoriteId)
+                .toList();
+
+        // 삭제할 즐겨찾기가 선택되지않음
+        if (favoriteIds.isEmpty()) {
+            throw new GlobalException(NOT_SELECTED_FAVORITE);
+        }
+
+        // 존재하는 즐겨찾기인지 확인
+        List<Favorite> favorites = favoriteRepository.findAllById(favoriteIds);
+        if (favorites.isEmpty()) {
+            throw new GlobalException(CANNOT_FOUND_FAVORITE);
+        }
+
+        // 사용자 소유의 즐겨찾기인지 검증
+        if (favorites.stream().anyMatch(favorite -> !favorite.getUser().equals(user))) {
+            throw new GlobalException(CANNOT_DELETE_FAVORITE);
+        }
+
+        // 즐겨찾기 삭제 (Batch 처리)
+        favoriteRepository.deleteAllByIdInBatch(favoriteIds);
+        // 영속성 컨텍스트 초기화하여 최신 상태 반영
+        entityManager.flush();
+        entityManager.clear();
+        return null;
+    }
 }

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -94,9 +94,12 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     CANNOT_DELETE_RECENT_SEARCH(10001,BAD_REQUEST, "최근검색어를 삭제 할 수 없습니다."),
 
     /**
-     * 11000 : recentSearch 관련
+     * 11000 : favorite 관련
      */
-    CANNOT_FAVORITE(11000,BAD_REQUEST, "이미 즐겨찾기 한 책입니다.");
+    CANNOT_FAVORITE(11000,BAD_REQUEST, "이미 즐겨찾기 한 책입니다."),
+    CANNOT_FOUND_FAVORITE(11001,BAD_REQUEST, "즐겨찾기를 찾을 수 없습니다."),
+    NOT_SELECTED_FAVORITE(11002,BAD_REQUEST, "삭제할 즐겨찾기 ID가 선택되지 않았습니다."),
+    CANNOT_DELETE_FAVORITE(11003,BAD_REQUEST, "즐겨찾기를 삭제 할 수 없습니다.");
 
     private final int code;
     private final HttpStatus status;


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #117

## 📝작업 내용
<img width="134" alt="image" src="https://github.com/user-attachments/assets/6e74a7e9-531a-4bc0-8130-e1e95ad38298" />
<img width="136" alt="image" src="https://github.com/user-attachments/assets/290159b9-eb8c-45e6-9577-ef9112b98841" />

- 즐겨찾기 선택삭제 기능을 구현했습니다.
- 아래의 3가지의 검증을 진행하고 즐겨찾기 선택삭제를 진행합니다
     * 1.삭제할 즐겨찾기 선택되었는지 검증(리스트가 비어서 요청보내진건지 검증)
     * 2.존재하는 즐겨찾기인지 검증
     * 3.요청을 보낸 사용자가 등록한 즐겨찾기인지 검증
- `Long` 타입의 `favoriteId`에 `@ NotBlank` 어노테이션을 사용할수없기때문에 서비스로직에서 빈 리스트에대한 검증을 진행했습니다.

### 스크린샷 (선택)
**삭제할 즐겨찾기가 하나도 선택안되었을 경우**
![image](https://github.com/user-attachments/assets/231cf73c-bb4e-452f-a703-c93ded5dbdc8)
**존재하지 않는 즐겨찾기일 경우**
![image](https://github.com/user-attachments/assets/ed59fbe7-8bc7-48ac-83c8-1f5b562f174e)
**사용자가 등록하지않은 즐겨찾기 일경우**
![image](https://github.com/user-attachments/assets/16ae2edb-3356-424f-8a8b-031be99f7f5c)


![image](https://github.com/user-attachments/assets/7c534868-1dff-43b7-bf64-ec6afbecd78f)
![image](https://github.com/user-attachments/assets/a5f49130-051c-4a52-b7e8-2e53a90e6d6f)
![image](https://github.com/user-attachments/assets/ff1d672f-9ee3-45f7-8402-c490f860af2c)
선택삭제가 정상적으로 진행되는것을 확인할 수 있습니다!

## 💬리뷰 요구사항(선택)

> 추가적으로 엑세스토큰 재발급 검증 어노테이션이 잘못되어있는것을 발견해버려서 한줄 같이 수정했습니다,,
