### PR TITLE
[REFACTOR] 혼자읽기 방 생성시 제한 추가

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
@@ -261,6 +261,9 @@ public class RoomService {
     private Room createRoom(PostRoomCreateRequest request, Book book, UserRoom userRoom) {
         Room room;
         if (request.getRecruitCount() == 1) {
+            if(userRoomRepository.existsUnExpiredAloneRoomByUserAndBook(userRoom.getUser().getUserId(), book.getIsbn())) {
+                throw new GlobalException(ALREADY_CREATED_ALONE_ROOM);
+            }
             room = Room.makeReadAloneRoom(book);
         } else {
             validatedRoomCreateRequest(request);

--- a/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
@@ -7,6 +7,7 @@ import com.example.bookjourneybackend.global.entity.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -50,4 +51,14 @@ public interface UserRoomRepository extends JpaRepository<UserRoom, Long> {
             "AND (r.progressEndDate IS NULL OR (MONTH(r.progressEndDate) >= :month AND YEAR(r.progressEndDate) >= :year)) " +
             "AND r.roomType = 'ALONE'")
     List<UserRoom> findInActiveAloneRoomsByUserIdAndDate(@Param("userId") Long userId, @Param("year") Integer year, @Param("month") Integer month, @Param("status") EntityStatus status);
+
+
+    //해당 User가 Book으로 혼자읽기 방을 이미 만들었고 그 혼자읽기 방의 status가 EXPIRED가 아니라면 true
+    @Query(
+            "SELECT CASE WHEN COUNT(ur) > 0 THEN TRUE ELSE FALSE END " +
+                    "FROM UserRoom ur " +
+                    "LEFT JOIN ur.room r " +
+                    "WHERE ur.user.userId = :userId AND r.book.isbn = :isbn AND r.roomType = 'ALONE' AND r.status != 'EXPIRED'"
+    )
+    boolean existsUnExpiredAloneRoomByUserAndBook(@Param("userId") Long userId, @Param("isbn") String isbn);
 }

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -82,6 +82,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
 
     CANNOT_NULL_DATE(8009, BAD_REQUEST, "같이읽기 방 생성시, 기간은 필수 입력값입니다."),
     CANNOT_NULL_PASSWORD(8010, BAD_REQUEST, "비공개 방 생성시, 비밀번호는 필수 입력값입니다."),
+    ALREADY_CREATED_ALONE_ROOM(8011, BAD_REQUEST, "이미 해당 책으로 생성된 혼자읽기 방이 존재합니다."),
 
     /**
      * 9000 : record 관련


### PR DESCRIPTION
## #️⃣연관된 이슈

- #121 

## 📝작업 내용

> 혼자읽기로 방을 생성할때 로그인된 사용자가 해당 책으로 이미 생성한 혼자읽기 방이 아직 EXPIRED 상태가 아니라면 생성을 못하게끔 수정

### 스크린샷 (선택)
<img width="847" alt="스크린샷 2025-02-05 오후 5 50 47" src="https://github.com/user-attachments/assets/b017a848-1923-4b07-85d6-30dcaee427e8" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
