### PR TITLE
[REFACTOR] 책/방 검색시 최근 검색어 추가 

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/book/controller/BookController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/controller/BookController.java
@@ -22,8 +22,9 @@ public class BookController {
     private final BookService bookService;
 
     @GetMapping("/search")
-    public BaseResponse<GetBookListResponse> viewBookList(@Valid final GetBookListRequest getBookListRequest) {
-        return BaseResponse.ok(bookService.searchBook(getBookListRequest));
+    public BaseResponse<GetBookListResponse> viewBookList(@Valid final GetBookListRequest getBookListRequest,
+                                                          @LoginUserId final Long userId) {
+        return BaseResponse.ok(bookService.searchBook(getBookListRequest, userId));
     }
 
     @GetMapping("/info/{isbn}")

--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
@@ -6,6 +6,7 @@ import com.example.bookjourneybackend.domain.book.domain.repository.BookReposito
 import com.example.bookjourneybackend.domain.book.dto.request.GetBookListRequest;
 import com.example.bookjourneybackend.domain.book.dto.response.*;
 import com.example.bookjourneybackend.domain.favorite.domain.repository.FavoriteRepository;
+import com.example.bookjourneybackend.domain.recentSearch.service.RecentSearchService;
 import com.example.bookjourneybackend.domain.user.domain.FavoriteGenre;
 import com.example.bookjourneybackend.domain.user.domain.User;
 import com.example.bookjourneybackend.domain.user.domain.repository.UserRepository;
@@ -40,6 +41,8 @@ public class BookService {
     private final BookCacheService bookCacheService;
     private final UserRepository userRepository;
 
+    private final RecentSearchService recentSearchService;
+
     /**
      * 1. Redis에 있는지 확인하고 있으면 Redis에 value로 반환
      * 2. RestTemplate을 이용해 동기적으로 현재 페이지 불러와서 Redis에 저장 후 응답 전송
@@ -49,8 +52,10 @@ public class BookService {
      * @return
      */
     //todo Thread Pool Monitoring 로그 출력
-    public GetBookListResponse searchBook(GetBookListRequest getBookListRequest) {
+    public GetBookListResponse searchBook(GetBookListRequest getBookListRequest, Long userId) {
         log.info("------------------------[BookService.searchBook]------------------------");
+
+        recentSearchService.addRecentSearch(userId, getBookListRequest.getSearchTerm());
 
         // 현재 페이지 데이터 가져오기
         String currentResponse = bookCacheService.getCurrentPage(getBookListRequest);

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/repository/RecentSearchRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/repository/RecentSearchRepository.java
@@ -10,7 +10,12 @@ import java.util.Optional;
 
 @Repository
 public interface RecentSearchRepository extends JpaRepository<RecentSearch, Long> {
-    Optional<List<RecentSearch>>  findTop12ByUserOrderByCreatedAtDesc(User user);
+    Optional<List<RecentSearch>>  findTop12ByUserOrderByModifiedAtDesc(User user);
     Optional<List<RecentSearch>>  findByUser(User user);
     Optional<RecentSearch> findByUserAndRecentSearchId(User user, Long recentSearchId);
+    Optional<RecentSearch> findByUserAndRecentSearch(User user, String recentSearch);
+
+    Optional<Integer> countRecentSearchByUser(User user);
+
+    Optional<RecentSearch> findTop1ByUserOrderByModifiedAtAsc(User user);
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/room/controller/RoomController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/controller/RoomController.java
@@ -43,10 +43,11 @@ public class RoomController {
             @RequestParam(required = false) final String roomStartDate,
             @RequestParam(required = false) final String roomEndDate,
             @RequestParam(required = false) final Integer recordCount,
-            @RequestParam(required = true, defaultValue = "0") final Integer page
+            @RequestParam(required = true, defaultValue = "0") final Integer page,
+            @LoginUserId final Long userId
     ) {
         return BaseResponse.ok(
-                roomService.searchRooms(searchTerm, searchType, genre, recruitStartDate, recruitEndDate, roomStartDate, roomEndDate, recordCount, page)
+                roomService.searchRooms(searchTerm, searchType, genre, recruitStartDate, recruitEndDate, roomStartDate, roomEndDate, recordCount, page, userId)
         );
     }
 

--- a/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
@@ -2,6 +2,7 @@ package com.example.bookjourneybackend.domain.room.service;
 
 import com.example.bookjourneybackend.domain.book.domain.GenreType;
 import com.example.bookjourneybackend.domain.favorite.domain.repository.FavoriteRepository;
+import com.example.bookjourneybackend.domain.recentSearch.service.RecentSearchService;
 import com.example.bookjourneybackend.domain.record.domain.repository.RecordRepository;
 import com.example.bookjourneybackend.domain.room.domain.Room;
 import com.example.bookjourneybackend.domain.room.domain.SearchType;
@@ -58,6 +59,8 @@ public class RoomService {
     private final RecordRepository recordRepository;
     private final FavoriteRepository favoriteRepository;
 
+    private final RecentSearchService recentSearchService;
+
     /**
      * 방 상세정보 조회
      */
@@ -110,7 +113,7 @@ public class RoomService {
             String searchTerm, String searchType, String genre,
             String recruitStartDate, String recruitEndDate,
             String roomStartDate, String roomEndDate,
-            Integer recordCount, Integer page
+            Integer recordCount, Integer page, Long userId
     ) {
         log.info("------------------------[RoomService.searchRooms]------------------------");
 
@@ -118,6 +121,8 @@ public class RoomService {
 
         SearchType effectiveSearchType = SearchType.from(searchType);
         GenreType genreType = genre != null && !genre.isEmpty() ? GenreType.fromGenreType(genre) : null;
+
+        recentSearchService.addRecentSearch(userId, searchTerm);
 
         Slice<Room> rooms = roomRepository.findRoomsByFilters(
                 genreType,

--- a/src/main/java/com/example/bookjourneybackend/global/entity/BaseEntity.java
+++ b/src/main/java/com/example/bookjourneybackend/global/entity/BaseEntity.java
@@ -27,6 +27,7 @@ public abstract class BaseEntity {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @Setter
     @LastModifiedDate
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     @JsonSerialize(using = LocalDateSerializer.class)


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #128 

## 📝작업 내용

1. 책 / 방 검색시 최근 검색어 추가
2. 이미 해당 사용자가 같은 검색어로 검색했다면 modified_at만 업데이트
3. 해당 사용자의 RecentSearch의 개수가 12개를 넘으면 자동으로 가장 오래된 RecentSearch 삭제 (무조건 12개로 제한)

### 스크린샷 (선택)
추가되는 것 확인했습니다! 
<img width="760" alt="스크린샷 2025-02-05 오후 6 49 25" src="https://github.com/user-attachments/assets/d357e367-bfbe-4bdf-b09c-a0b0bf31cc6c" />


## 💬리뷰 요구사항(선택)

> 방 검색도 책 검색과 같은 로직이라 한번에 했습니다!
