### PR TITLE
[REFACTOR] 댓글 정보 조회 시 기록 정보도 조회하게끔 수정

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/comment/domain/dto/response/GetCommentListResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/comment/domain/dto/response/GetCommentListResponse.java
@@ -1,5 +1,6 @@
 package com.example.bookjourneybackend.domain.comment.domain.dto.response;
 
+import com.example.bookjourneybackend.domain.record.dto.response.RecordInfo;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,12 +11,14 @@ import java.util.List;
 public class GetCommentListResponse {
 
     private List<CommentInfo> comments;
+    private RecordInfo recordInfo;
 
-    public GetCommentListResponse(List<CommentInfo> comments) {
+    public GetCommentListResponse(List<CommentInfo> comments, RecordInfo recordInfo) {
         this.comments = comments;
+        this.recordInfo = recordInfo;
     }
 
-    public static GetCommentListResponse of(List<CommentInfo> comments) {
-        return new GetCommentListResponse(comments);
+    public static GetCommentListResponse of(List<CommentInfo> comments, RecordInfo recordInfo) {
+        return new GetCommentListResponse(comments, recordInfo);
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/comment/service/CommentService.java
@@ -6,10 +6,13 @@ import com.example.bookjourneybackend.domain.comment.domain.dto.response.GetComm
 import com.example.bookjourneybackend.domain.comment.domain.repository.CommentLikeRepository;
 import com.example.bookjourneybackend.domain.comment.domain.repository.CommentRepository;
 import com.example.bookjourneybackend.domain.record.domain.Record;
+import com.example.bookjourneybackend.domain.record.domain.repository.RecordLikeRepository;
 import com.example.bookjourneybackend.domain.record.domain.repository.RecordRepository;
+import com.example.bookjourneybackend.domain.record.dto.response.RecordInfo;
 import com.example.bookjourneybackend.domain.user.domain.User;
 import com.example.bookjourneybackend.domain.user.domain.repository.UserRepository;
 import com.example.bookjourneybackend.global.exception.GlobalException;
+import com.example.bookjourneybackend.global.util.DateUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.example.bookjourneybackend.domain.record.domain.RecordType.PAGE;
 import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_RECORD;
 import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_USER;
 
@@ -29,6 +33,8 @@ public class CommentService {
     private final CommentLikeRepository commentLikeRepository;
     private final UserRepository userRepository;
     private final RecordRepository recordRepository;
+    private final RecordLikeRepository recordLikeRepository;
+    private final DateUtil dateUtil;
 
     @Transactional(readOnly = true)
     public GetCommentListResponse showComments(Long recordId, Long userId) {
@@ -41,6 +47,37 @@ public class CommentService {
                 .map(comment -> CommentInfo.from(comment, commentLikeRepository.existsByCommentAndUser(comment, user)))
                 .toList();
 
-        return GetCommentListResponse.of(commentList);
+        RecordInfo recordInfo;
+        boolean isLiked = recordLikeRepository.existsByRecordAndUser(record, user);
+
+        if (record.getRecordType() == PAGE) {
+            recordInfo = RecordInfo.fromPageRecord(
+                    record.getUser().getUserId(),
+                    record.getRecordId(),
+                    (record.getUser().getUserImage() != null) ? record.getUser().getUserImage().getImageUrl() : null,
+                    record.getUser().getNickname(),
+                    record.getRecordPage(),
+                    dateUtil.formatLocalDateTime(record.getCreatedAt()),
+                    record.getContent(),
+                    record.getComments().size(),
+                    record.getRecordLikes().size(),
+                    isLiked
+            );
+        } else {
+            recordInfo = RecordInfo.fromEntireRecord(
+                    record.getUser().getUserId(),
+                    record.getRecordId(),
+                    (record.getUser().getUserImage() != null) ? record.getUser().getUserImage().getImageUrl() : null,
+                    record.getUser().getNickname(),
+                    record.getRecordTitle(),
+                    dateUtil.formatLocalDateTime(record.getCreatedAt()),
+                    record.getContent(),
+                    record.getComments().size(),
+                    record.getRecordLikes().size(),
+                    isLiked
+            );
+        }
+
+        return GetCommentListResponse.of(commentList, recordInfo);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #132 

## 📝작업 내용

- 프엔측 편의성을 위해 댓글을 조회 시 해당 댓글을 남긴 기록도 같이 조회하게끔 수정했습니다.

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/66f24541-1a16-41a9-bcd6-559213bb0124)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
