### PR TITLE
[FEAT] 즐겨찾기 삭제 구현

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BestSellerService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BestSellerService.java
@@ -31,6 +31,7 @@ public class BestSellerService {
     private final RestTemplate restTemplate;
     private final BookRepository bookRepository;
     private final FavoriteGenreRepository favoriteGenreRepository;
+    private final BookService bookService;
 
     @Transactional
     @Async
@@ -120,9 +121,10 @@ public class BestSellerService {
         oldBestSeller.setBestSeller(false);
         bookRepository.save(oldBestSeller);
         //이 책에해당하는 방이 없거나, 이책을 즐겨찾기 한사람이 없으면 db에서 삭제
-        if(oldBestSeller.getRooms().isEmpty() && oldBestSeller.getFavorites().isEmpty()) {
-            bookRepository.delete(oldBestSeller);
-        }
+        bookService.deleteBook(oldBestSeller);
+//        if(oldBestSeller.getRooms().isEmpty() && oldBestSeller.getFavorites().isEmpty()) {
+//            bookRepository.delete(oldBestSeller);
+//        }
     }
 
 

--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BestSellerService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BestSellerService.java
@@ -118,9 +118,6 @@ public class BestSellerService {
         bookRepository.save(oldBestSeller);
         //이 책에해당하는 방이 없거나, 이책을 즐겨찾기 한사람이 없으면 db에서 삭제
         bookService.deleteBook(oldBestSeller);
-//        if(oldBestSeller.getRooms().isEmpty() && oldBestSeller.getFavorites().isEmpty()) {
-//            bookRepository.delete(oldBestSeller);
-//        }
     }
 
 

--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
@@ -11,14 +11,12 @@ import com.example.bookjourneybackend.domain.user.domain.FavoriteGenre;
 import com.example.bookjourneybackend.domain.user.domain.User;
 import com.example.bookjourneybackend.domain.user.domain.repository.UserRepository;
 import com.example.bookjourneybackend.global.exception.GlobalException;
-import com.example.bookjourneybackend.global.util.AladinApiUtil;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -169,6 +170,13 @@ public class BookService {
         }
         return GetBookBestSellersResponse.of(imageUrls);
 
+    }
+
+    @Transactional
+    public void deleteBook(Book book) {
+        if(book.getRooms().isEmpty() && book.getFavorites().isEmpty()){
+            bookRepository.delete(book);
+        }
     }
 
 

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/controller/FavoriteController.java
@@ -37,4 +37,9 @@ public class FavoriteController {
         log.info("[FavoriteController.deleteSelectedFavorite]");
         return BaseResponse.ok(favoriteService.deleteSelectedFavorite(deleteFavoriteSelectedRequest,userId));
     }
+
+    @DeleteMapping("/{isbn}")
+    public BaseResponse<PostFavoriteAddResponse> deleteFavorite(@PathVariable("isbn") final String isbn, @LoginUserId final Long userId) {
+        return BaseResponse.ok(favoriteService.deleteFavorite(isbn,userId));
+    }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/repository/FavoriteRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/repository/FavoriteRepository.java
@@ -4,6 +4,7 @@ import com.example.bookjourneybackend.domain.book.domain.Book;
 import com.example.bookjourneybackend.domain.favorite.domain.Favorite;
 import com.example.bookjourneybackend.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -22,4 +23,5 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
     Optional<List<Favorite>> findByUserOrderByCreatedAtDesc(User user);
 
+    void deleteFavoriteByUserAndBook(User user, Book book);
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
@@ -203,7 +203,7 @@ public class FavoriteService {
 
         //즐겨찾기에서 삭제
         favoriteRepository.deleteFavoriteByUserAndBook(user,book);
-        entityManager.flush();
+        favoriteRepository.flush();
 
         //즐겨찾기한 책 db에서 삭제
         bookService.deleteBook(book);

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
@@ -209,7 +209,8 @@ public class FavoriteService {
 
         //즐겨찾기에서 삭제
         favoriteRepository.deleteFavoriteByUserAndBook(user,book);
-        log.info("{}{} {} {} ",book.getBookTitle(),book.getIsbn(),user.getUserId(),user.getNickname());
+        entityManager.flush();
+
         //즐겨찾기한 책 db에서 삭제
         bookService.deleteBook(book);
 

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
@@ -6,6 +6,7 @@ import com.example.bookjourneybackend.domain.book.domain.repository.BookReposito
 import com.example.bookjourneybackend.domain.book.dto.response.BookInfo;
 import com.example.bookjourneybackend.domain.book.dto.response.GetBookInfoResponse;
 import com.example.bookjourneybackend.domain.book.service.BookCacheService;
+import com.example.bookjourneybackend.domain.book.service.BookService;
 import com.example.bookjourneybackend.domain.favorite.domain.Favorite;
 import com.example.bookjourneybackend.domain.favorite.domain.dto.request.DeleteFavoriteSelectedRequest;
 import com.example.bookjourneybackend.domain.favorite.domain.dto.response.GetFavoriteListResponse;
@@ -25,6 +26,8 @@ import org.springframework.transaction.annotation.Transactional;
 import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.*;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_BOOK;
 import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_USER;
@@ -40,6 +43,7 @@ public class FavoriteService {
     private final BookRepository bookRepository;
     private final BookCacheService bookCacheService;
     private final DateUtil dateUtil;
+    private final BookService bookService;
     @PersistenceContext
     private final EntityManager entityManager;
 
@@ -129,6 +133,7 @@ public class FavoriteService {
      * 2.존재하는 즐겨찾기인지 검증
      * 3.요청을 보낸 사용자가 등록한 즐겨찾기인지 검증
      * 4.선택한 즐겨찾기 전체삭제
+     * 5.선택한 즐겨찾기의 책에해당하는 방이 없거나, 이책을 즐겨찾기 한사람이 없으면 db에서 삭제
      * @param deleteFavoriteSelectedRequest,userId
      */
     public Void deleteSelectedFavorite(DeleteFavoriteSelectedRequest deleteFavoriteSelectedRequest, Long userId) {
@@ -157,11 +162,57 @@ public class FavoriteService {
             throw new GlobalException(CANNOT_DELETE_FAVORITE);
         }
 
+        // 삭제할 Favorite이 참조하는 Book 목록 가져오기
+        Set<Book> booksToCheck = favorites.stream()
+                .map(Favorite::getBook)
+                .collect(Collectors.toSet());
+
         // 즐겨찾기 삭제 (Batch 처리)
         favoriteRepository.deleteAllByIdInBatch(favoriteIds);
+
+        // 삭제할 수 있는 Book 삭제
+        for (Book book : booksToCheck) {
+            bookService.deleteBook(book);
+        }
+
         // 영속성 컨텍스트 초기화하여 최신 상태 반영
         entityManager.flush();
         entityManager.clear();
+
         return null;
+    }
+
+
+    /**
+     * isbn에 해당하는 책을 즐겨찾기에서 삭제
+     * 1. 해당책이 이미 즐겨찾기 되어있는지 검사
+     * 2. 즐겨찾기 중이 아니라면 예외
+     * 3. 즐겨찾기 삭제 후, 책이 삭제할수 있는 상태라면 db에서 삭제
+     * @param isbn,userId
+     * @return PostFavoriteAddResponse
+     */
+    public PostFavoriteAddResponse deleteFavorite(String isbn, Long userId) {
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
+
+        // 즐겨찾기 중인지 검사
+        if (!favoriteRepository.existsFavoriteByUserIdAndIsbn(userId, isbn)) {
+            throw new GlobalException(CANNOT_DELETE_FAVORITE);
+        }
+
+        //즐겨찾기 한 책 찾기
+        Book book = bookRepository.findByIsbn(isbn)
+                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_BOOK));
+        log.info("{}{}",book.getBookTitle(),book.getIsbn());
+
+        //즐겨찾기에서 삭제
+        favoriteRepository.deleteFavoriteByUserAndBook(user,book);
+        log.info("{}{} {} {} ",book.getBookTitle(),book.getIsbn(),user.getUserId(),user.getNickname());
+        //즐겨찾기한 책 db에서 삭제
+        bookService.deleteBook(book);
+
+        return PostFavoriteAddResponse.of(book.getBookId(),false);
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
@@ -200,7 +200,6 @@ public class FavoriteService {
         //즐겨찾기 한 책 찾기
         Book book = bookRepository.findByIsbn(isbn)
                 .orElseThrow(() -> new GlobalException(CANNOT_FOUND_BOOK));
-        log.info("{}{}",book.getBookTitle(),book.getIsbn());
 
         //즐겨찾기에서 삭제
         favoriteRepository.deleteFavoriteByUserAndBook(user,book);


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #126 
## 📝작업 내용

- 즐겨찾기 삭제 기능을 구현했습니다.
- 추가로 즐겨찾기 선택삭제에서 db에서 책을 삭제하는 부분이 빠졌어서 같이 추가했습니다.
- 즐겨찾기하려는 책이 즐겨찾기 삭제가능한지 검사한뒤, isbn코드로 해당하는 책을찾고 즐겨찾기 테이블에서 삭제됩니다.
- 베스트셀러 서비스와 마찬가지로 해당하는 책이 다른 누군가가 즐겨찾기 중이거나, 방이 생성된 상태라면 db에서 삭제되지않고 아니라면 db에서 삭제됩니다

### 스크린샷 (선택)
db에서 변경되는 사항 다 확인했습니다! 
## 💬리뷰 요구사항(선택)
