### PR TITLE
[FIX]: 즐겨찾기 조회 dto에 누락되었던 FavoriteId 추가 

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/dto/response/FavoriteInfo.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/domain/dto/response/FavoriteInfo.java
@@ -1,22 +1,22 @@
 package com.example.bookjourneybackend.domain.favorite.domain.dto.response;
 
 import com.example.bookjourneybackend.domain.book.dto.response.BookInfo;
+import com.example.bookjourneybackend.domain.favorite.domain.Favorite;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 import static lombok.AccessLevel.PRIVATE;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor(access = PRIVATE)
-public class GetFavoriteListResponse {
+public class FavoriteInfo {
 
-    private List<FavoriteInfo> favoriteList;
+    private Long favoriteId;
+    private BookInfo bookInfo;
 
-    public static GetFavoriteListResponse of(List<FavoriteInfo> favoriteList) {
-        return new GetFavoriteListResponse(favoriteList);
+    public static FavoriteInfo of(Favorite favorite) {
+        return new FavoriteInfo(favorite.getFavoriteId(), BookInfo.of(favorite.getBook()));
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/favorite/service/FavoriteService.java
@@ -8,6 +8,7 @@ import com.example.bookjourneybackend.domain.book.dto.response.GetBookInfoRespon
 import com.example.bookjourneybackend.domain.book.service.BookCacheService;
 import com.example.bookjourneybackend.domain.favorite.domain.Favorite;
 import com.example.bookjourneybackend.domain.favorite.domain.dto.request.DeleteFavoriteSelectedRequest;
+import com.example.bookjourneybackend.domain.favorite.domain.dto.response.FavoriteInfo;
 import com.example.bookjourneybackend.domain.favorite.domain.dto.response.GetFavoriteListResponse;
 import com.example.bookjourneybackend.domain.favorite.domain.dto.response.PostFavoriteAddResponse;
 import com.example.bookjourneybackend.domain.favorite.domain.repository.FavoriteRepository;
@@ -110,13 +111,13 @@ public class FavoriteService {
                 .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
 
         //즐겨찾기 리스트 조회
-        List<BookInfo> bookList = favoriteRepository.findByUserOrderByCreatedAtDesc(user)
+        List<FavoriteInfo> favoriteList = favoriteRepository.findByUserOrderByCreatedAtDesc(user)
                 .orElseGet(Collections::emptyList)
                 .stream()
-                .map(fav -> BookInfo.of(fav.getBook()))
+                .map(FavoriteInfo::of)
                 .toList();
 
-        return GetFavoriteListResponse.of(bookList);
+        return GetFavoriteListResponse.of(favoriteList);
     }
 
     /**


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #152 

## 📝작업 내용

- 즐겨찾기 조회 response에 dto에 누락되었던 `FavoriteId`를 추가해서 수정했습니다.
- 추가적으로 기존에 사용하던 `bookInfo`를 재이용하기위해서 `favoriteInfo`를 생성해서 사용했습니다

### 스크린샷 (선택)
<img width="428" alt="image" src="https://github.com/user-attachments/assets/41ca643c-fc49-4809-9fd6-8b4d52747db8" />
