### PR TITLE
[FEAT] 독서달력 조회용 api 구현

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
@@ -30,6 +30,7 @@ import static com.example.bookjourneybackend.domain.room.domain.RoomType.ALONE;
 import static com.example.bookjourneybackend.global.entity.EntityStatus.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -261,6 +262,11 @@ public class RecordService {
         // 유저의 진행률 & current page 업데이트
         double userPercentage = ((double) currentPage / totalPages) * 100;
         userRoom.updateUserProgress(userPercentage, currentPage);
+
+        //유저가 책을 다읽으면 독서달력을 위해 현재 시각을 저장
+        if (userPercentage >= 100) {
+            userRoom.setCompletedUserPercentageAt(LocalDateTime.now());
+        }
 
         // 방의 진행률 업데이트
         List<UserRoom> roomMembers = userRoomRepository.findAllByRoom(room);

--- a/src/main/java/com/example/bookjourneybackend/domain/user/controller/MyPageController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/controller/MyPageController.java
@@ -1,0 +1,27 @@
+package com.example.bookjourneybackend.domain.user.controller;
+
+import com.example.bookjourneybackend.domain.user.dto.response.GetMyPageCalendarResponse;
+import com.example.bookjourneybackend.domain.user.service.MyPageService;
+import com.example.bookjourneybackend.global.annotation.LoginUserId;
+import com.example.bookjourneybackend.global.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users/mypage")
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    @GetMapping("/calendar")
+    public BaseResponse<GetMyPageCalendarResponse> getMyPageCalendar(
+            @LoginUserId final Long userId,
+            @RequestParam final Integer month,
+            @RequestParam final Integer year) {
+        return BaseResponse.ok(myPageService.showMyPageCalendar(userId, month, year));
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/user/dto/response/CalendarData.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/dto/response/CalendarData.java
@@ -1,0 +1,10 @@
+package com.example.bookjourneybackend.domain.user.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CalendarData(
+        String date,
+        String imageUrl
+){
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/user/dto/response/GetMyPageCalendarResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/dto/response/GetMyPageCalendarResponse.java
@@ -1,0 +1,23 @@
+package com.example.bookjourneybackend.domain.user.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class GetMyPageCalendarResponse {
+    private List<CalendarData> calendarList;
+
+    public GetMyPageCalendarResponse(List<CalendarData> calendarList) {
+        this.calendarList = calendarList;
+    }
+
+    public static GetMyPageCalendarResponse of(List<CalendarData> calendarList) {
+        return new GetMyPageCalendarResponse(calendarList);
+    }
+}
+
+
+

--- a/src/main/java/com/example/bookjourneybackend/domain/user/service/MyPageService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/service/MyPageService.java
@@ -1,0 +1,66 @@
+package com.example.bookjourneybackend.domain.user.service;
+
+import com.example.bookjourneybackend.domain.book.domain.Book;
+import com.example.bookjourneybackend.domain.room.domain.repository.RoomRepository;
+import com.example.bookjourneybackend.domain.user.domain.User;
+import com.example.bookjourneybackend.domain.user.domain.repository.UserRepository;
+import com.example.bookjourneybackend.domain.user.dto.response.CalendarData;
+import com.example.bookjourneybackend.domain.user.dto.response.GetMyPageCalendarResponse;
+import com.example.bookjourneybackend.domain.userRoom.domain.repository.UserRoomRepository;
+import com.example.bookjourneybackend.global.exception.GlobalException;
+import com.example.bookjourneybackend.global.util.DateUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_USER;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final RoomRepository roomRepository;
+    private final UserRepository userRepository;
+    private final UserRoomRepository userRoomRepository;
+    private final DateUtil dateUtil;
+
+    /**
+     * 마이페이지 캘린더 조회
+     * UserRoom에서 userPercentage가 100%인 데이터 조회
+     * 파라미터로 넘어온 month와 year와 completedUserPercentageAt이 같은 데이터 조회
+     * 같은 날짜의 completedUserPercentageAt이 있으면 가장 최근에 완료된 UserRoom의 책 이미지를 가져와서 반환
+     */
+    public GetMyPageCalendarResponse showMyPageCalendar(Long userId, Integer month, Integer year) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
+
+        if(month == null) {
+            month = LocalDate.now().getMonthValue();
+        }
+        if(year == null) {
+            year = LocalDate.now().getYear();
+        }
+
+
+        return GetMyPageCalendarResponse.of(parseUserRoomToCalendarData(userId, month, year));
+    }
+
+    private List<CalendarData> parseUserRoomToCalendarData(Long userId, Integer month, Integer year) {
+        // UserRoom의 userPercentage가 100%인 Room 중에 현재 month와 completedUserPercentageAt이 같은 것을 조회
+        List<CalendarData> calendarDataList = userRoomRepository.findUserRoomsByUserInCalendar(userId, year, month)
+                .stream()
+                .map(userRoom -> {
+                    LocalDate localDate = userRoom.getCompletedUserPercentageAt().toLocalDate();
+                    Book book = userRoom.getRoom().getBook();
+                    return CalendarData.builder()
+                            .date(dateUtil.formatDate(localDate))
+                            .imageUrl(book.getImageUrl())
+                            .build();
+                }).collect(Collectors.toList());
+        return calendarDataList;
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/UserRoom.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/UserRoom.java
@@ -40,6 +40,9 @@ public class UserRoom extends BaseEntity {
     @Setter
     private LocalDateTime inActivatedAt;
 
+    @Setter
+    private LocalDateTime completedUserPercentageAt;
+
     // Room의 관계 추가
     @Setter
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
@@ -60,4 +60,17 @@ public interface UserRoomRepository extends JpaRepository<UserRoom, Long> {
                     "WHERE ur.user.userId = :userId AND r.book.isbn = :isbn AND r.roomType = 'ALONE' AND r.status != 'EXPIRED'"
     )
     boolean existsUnExpiredAloneRoomByUserAndBook(@Param("userId") Long userId, @Param("isbn") String isbn);
+
+    @Query("SELECT ur FROM UserRoom ur " +
+            "WHERE ur.user.userId = :userId AND ur.userPercentage >= 100 " +
+            "AND MONTH(ur.completedUserPercentageAt) = :month AND YEAR(ur.completedUserPercentageAt) = :year " +
+            "AND ur.completedUserPercentageAt IN (" +
+            "    SELECT MIN(ur2.completedUserPercentageAt) " +
+            "    FROM UserRoom ur2 " +
+            "    WHERE ur2.user.userId = :userId AND ur2.userPercentage >= 100 " +
+            "    AND MONTH(ur2.completedUserPercentageAt) = :month AND YEAR(ur2.completedUserPercentageAt) = :year " +
+            "    GROUP BY DAY(ur2.completedUserPercentageAt)" +
+            ") " +
+            "ORDER BY ur.completedUserPercentageAt ASC")
+    List<UserRoom> findUserRoomsByUserInCalendar(@Param("userId") Long userId, @Param("year") Integer year, @Param("month") Integer month);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #156 

## 📝작업 내용

> 로그인한 사용자가 완료한 책 (즉, userPercentage가 100인 Room의 책)을 조회합니다. 이때, 같은 날짜에 완료된 책이 존재하면 가장 처음 완료된 책의 표지를 반환합니다.

### 스크린샷 (선택)
Postman으로 테스트 완료했습니다. 
<img width="847" alt="스크린샷 2025-02-09 오후 8 18 04" src="https://github.com/user-attachments/assets/15c844c9-5d2b-4aa7-aeea-297d346a44ad" />

## 💬리뷰 요구사항(선택)

> 추가로, 사용자가 책을 다읽은 시기를 저장하기 위해 UserRoom에 completedUserPercentage 필드를 추가하고 페이지 입력시에 100이면 업데이트하도록 하였습니다!

