### PR TITLE
[FEAT] 마이페이지 유저 정보

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/user/controller/MyPageController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/controller/MyPageController.java
@@ -1,6 +1,7 @@
 package com.example.bookjourneybackend.domain.user.controller;
 
 import com.example.bookjourneybackend.domain.user.dto.response.GetMyPageCalendarResponse;
+import com.example.bookjourneybackend.domain.user.dto.response.GetMyPageUserInfoResponse;
 import com.example.bookjourneybackend.domain.user.service.MyPageService;
 import com.example.bookjourneybackend.global.annotation.LoginUserId;
 import com.example.bookjourneybackend.global.response.BaseResponse;
@@ -23,5 +24,12 @@ public class MyPageController {
             @RequestParam final Integer month,
             @RequestParam final Integer year) {
         return BaseResponse.ok(myPageService.showMyPageCalendar(userId, month, year));
+    }
+
+    @GetMapping
+    public BaseResponse<GetMyPageUserInfoResponse> getMyPageCalendar(
+            @LoginUserId final Long userId
+    ) {
+        return BaseResponse.ok(myPageService.showMyPageUserInfo(userId));
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/user/dto/response/GetMyPageUserInfoResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/dto/response/GetMyPageUserInfoResponse.java
@@ -1,0 +1,17 @@
+package com.example.bookjourneybackend.domain.user.dto.response;
+
+import com.example.bookjourneybackend.domain.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetMyPageUserInfoResponse {
+    private String imageUrl;
+    private String nickname;
+    private String email;
+
+    public static GetMyPageUserInfoResponse of(User user) {
+        return new GetMyPageUserInfoResponse(user.getImageUrl(), user.getNickname(), user.getEmail());
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/user/service/MyPageService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/service/MyPageService.java
@@ -6,6 +6,7 @@ import com.example.bookjourneybackend.domain.user.domain.User;
 import com.example.bookjourneybackend.domain.user.domain.repository.UserRepository;
 import com.example.bookjourneybackend.domain.user.dto.response.CalendarData;
 import com.example.bookjourneybackend.domain.user.dto.response.GetMyPageCalendarResponse;
+import com.example.bookjourneybackend.domain.user.dto.response.GetMyPageUserInfoResponse;
 import com.example.bookjourneybackend.domain.userRoom.domain.repository.UserRoomRepository;
 import com.example.bookjourneybackend.global.exception.GlobalException;
 import com.example.bookjourneybackend.global.util.DateUtil;
@@ -62,5 +63,15 @@ public class MyPageService {
                             .build();
                 }).collect(Collectors.toList());
         return calendarDataList;
+    }
+
+    /**
+     * 마이페이지 처음 진입했을 때 유저 정보를 반환
+     */
+    public GetMyPageUserInfoResponse showMyPageUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
+
+        return GetMyPageUserInfoResponse.of(user);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #148 

## 📝작업 내용

- 마이페이지에 접속하자마자 필요한 정보들 (프로필 이미지, 닉네임, 이메일)을 반환합니다

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/4a4711ec-0f0c-4ee4-83d6-0eb56caca32e)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
