### PR TITLE
[FEAT] 독서달력 상세보기 api 구현

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/user/controller/MyPageController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/controller/MyPageController.java
@@ -24,4 +24,14 @@ public class MyPageController {
             @RequestParam final Integer year) {
         return BaseResponse.ok(myPageService.showMyPageCalendar(userId, month, year));
     }
+
+    @GetMapping("/calendar/info")
+    public BaseResponse<GetMyPageCalendarResponse> getMyPageCalendarInfo(
+            @LoginUserId final Long userId,
+            @RequestParam final Integer month,
+            @RequestParam final Integer year,
+            @RequestParam final Integer day) {
+        return BaseResponse.ok(myPageService.showMyPageCalendarInfo(userId, month, year, day));
+    }
+
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/user/dto/response/CalendarData.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/dto/response/CalendarData.java
@@ -5,6 +5,9 @@ import lombok.Builder;
 @Builder
 public record CalendarData(
         String date,
-        String imageUrl
+        String imageUrl,
+        String bookTitle,
+        String authorName,
+        String roomType
 ){
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/user/service/MyPageService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/service/MyPageService.java
@@ -36,9 +36,6 @@ public class MyPageService {
      * 같은 날짜의 completedUserPercentageAt이 있으면 가장 최근에 완료된 UserRoom의 책 이미지를 가져와서 반환
      */
     public GetMyPageCalendarResponse showMyPageCalendar(Long userId, Integer month, Integer year) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
-
         if(month == null) {
             month = LocalDate.now().getMonthValue();
         }

--- a/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
@@ -73,4 +73,10 @@ public interface UserRoomRepository extends JpaRepository<UserRoom, Long> {
             ") " +
             "ORDER BY ur.completedUserPercentageAt ASC")
     List<UserRoom> findUserRoomsByUserInCalendar(@Param("userId") Long userId, @Param("year") Integer year, @Param("month") Integer month);
+
+    @Query("SELECT ur FROM UserRoom ur " +
+            "WHERE ur.user.userId = :userId AND ur.userPercentage >= 100 " +
+            "AND MONTH(ur.completedUserPercentageAt) = :month AND YEAR(ur.completedUserPercentageAt) = :year " +
+            "AND DAY(ur.completedUserPercentageAt) = :date ORDER BY ur.completedUserPercentageAt ASC")
+    List<UserRoom> findUserRoomsByUserInCalendarInfo(@Param("userId") Long userId, @Param("year") Integer year, @Param("month") Integer month, @Param("date") Integer date);
 }

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -125,7 +125,12 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     /**
      * 12000 : comment 관련
      */
-    CANNOT_FOUND_COMMENT(12001, BAD_REQUEST, "댓글을 찾을 수 없습니다.");
+    CANNOT_FOUND_COMMENT(12001, BAD_REQUEST, "댓글을 찾을 수 없습니다."),
+
+    /**
+     * 13000 : mypage 관련
+     */
+    INVALID_DATE(13000, BAD_REQUEST, "유효하지 않은 날짜입니다.");
 
     private final int code;
     private final HttpStatus status;


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #159 

## 📝작업 내용

> 독서달력에서 날짜 하나를 눌렀을때 해당 날짜에 userPercentage가 100이 된 방들을 보여줍니다.

<img width="459" alt="스크린샷 2025-02-10 오전 1 08 35" src="https://github.com/user-attachments/assets/5405a732-0751-480d-b493-bb7320c685ca" />

### 스크린샷 
<img width="847" alt="스크린샷 2025-02-10 오전 1 07 51" src="https://github.com/user-attachments/assets/dc01d19e-2bdb-491a-ade4-1756fbb0acad" />

## 💬리뷰 요구사항(선택)

> CalendarData에 필드를 추가하여 재사용하였습니다.
