### PR TITLE
[FIX] application.yml 수정 및 검색 메서드 오류 해결

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -57,7 +57,7 @@ jobs:
 
             cd bookJourney-backend
             git pull origin develop
-            sudo docker-compose down
+            sudo docker-compose down -v
 
              ./gradlew clean
              set -a && source .env && set +a && ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
     //AWS S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+    //StringEscapeUtils를 위한 commons-text 의존성 추가
+    implementation 'org.apache.commons:commons-text:1.10.0'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BookService.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.text.StringEscapeUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,6 +52,7 @@ public class BookService {
      * @return
      */
     //todo Thread Pool Monitoring 로그 출력
+    @Transactional
     public GetBookListResponse searchBook(GetBookListRequest getBookListRequest, Long userId) {
 
         recentSearchService.addRecentSearch(userId, getBookListRequest.getSearchTerm());
@@ -87,7 +89,7 @@ public class BookService {
 
             if (items != null && items.isArray()) {
                 for (JsonNode item : items) {
-                    String title = item.get("title").asText();
+                    String title = StringEscapeUtils.unescapeHtml4(item.get("title").asText());
                     String author = item.get("author").asText();
 
                     //isbn 13자리가 비어있는 경우 10자리 사용

--- a/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/service/RoomService.java
@@ -104,6 +104,7 @@ public class RoomService {
     /**
      * 방 검색
      */
+    @Transactional
     public GetRoomSearchResponse searchRooms(
             String searchTerm, String searchType, String genre,
             String recruitStartDate, String recruitEndDate,

--- a/src/main/java/com/example/bookjourneybackend/global/config/initData/DataLoader.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/initData/DataLoader.java
@@ -25,16 +25,16 @@ public class DataLoader implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments args) throws Exception {
-//         bookInitializer.initializeBooks();
-//         userInitializer.initializeUsers();
-//         roomInitializer.initializeRooms();
-//         userRoomInitializer.initializeUserRooms();
-//         recordInitializer.initializeRecords();
-//         commentInitializer.initializeComments();
-//         favoriteGenreInitializer.initializeFavoriteGenres();
-//         favoriteInitializer.initializeFavorites();
-//         recentSearchInitializer.initializeRecentSearches();
-//         recordLikeInitializer.initializeRecordLikes();
-//        commentLikeInitializer.initializeCommentLikes();
+         bookInitializer.initializeBooks();
+         userInitializer.initializeUsers();
+         roomInitializer.initializeRooms();
+         userRoomInitializer.initializeUserRooms();
+         recordInitializer.initializeRecords();
+         commentInitializer.initializeComments();
+         favoriteGenreInitializer.initializeFavoriteGenres();
+         favoriteInitializer.initializeFavorites();
+         recentSearchInitializer.initializeRecentSearches();
+         recordLikeInitializer.initializeRecordLikes();
+        commentLikeInitializer.initializeCommentLikes();
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/global/util/AladinApiUtil.java
+++ b/src/main/java/com/example/bookjourneybackend/global/util/AladinApiUtil.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.text.StringEscapeUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
@@ -135,7 +136,7 @@ public class AladinApiUtil {
 
                 selectedItem = items.get(nthItem);
 
-                String title = selectedItem.get("title").asText();
+                String title = StringEscapeUtils.unescapeHtml4(selectedItem.get("title").asText());
                 String author = selectedItem.get("author").asText();
 
 //              isbn 13자리가 비어있는 경우 10자리 사용

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,31 +13,12 @@ spring:
   config:
     activate:
       on-profile: local
-  #
-  #  datasource:
-  #    url: jdbc:mysql://localhost:3306/book_journey
-  #    username: ${LOCAL_DB_USER}
-  #    password: ${LOCAL_DB_PASSWORD}
-  #    driver-class-name: com.mysql.cj.jdbc.Driver
-  #
-  #  jpa:
-  #    hibernate:
-  #      ddl-auto: update
-  #    show-sql: true
-  #    properties:
-  #      hibernate:
-  #        format_sql: true
-  #        dialect: org.hibernate.dialect.MySQLDialect
 
   datasource:
-    url: jdbc:h2:mem:BookJourneyBackendApplication;MODE=MYSQL;
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
-
-  h2:
-    console:
-      enabled: true
+    url: jdbc:mysql://localhost:3306/book_journey
+    username: ${LOCAL_DB_USER}
+    password: ${LOCAL_DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     hibernate:
@@ -46,6 +27,25 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+
+#  datasource:
+#    url: jdbc:h2:mem:BookJourneyBackendApplication;MODE=MYSQL;
+#    username: sa
+#    password:
+#    driver-class-name: org.h2.Driver
+#
+#  h2:
+#    console:
+#      enabled: true
+#
+#  jpa:
+#    hibernate:
+#      ddl-auto: update
+#    show-sql: true
+#    properties:
+#      hibernate:
+#        format_sql: true
 
   data:
     redis:


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #163 

## 📝작업 내용

> application.yml을 수정하여 로컬에서도 mysql 사용하도록 하였습니다. 책 및 방 검색 메서드에서 최근검색어를 추가하기 때문에 `@Transactional` 을 추가하였습니다. 책 검색시에 책 제목에 '<' 등의 기호를 thymeleaf 형식으로 자동 변환하는 것을 막기 위해 String EscapeUtils.unescapeHtml4() 를 사용하여 html을 인식하지 않도록 했습니다..

### 스크린샷 (선택)
<img width="847" alt="스크린샷 2025-02-10 오전 2 28 48" src="https://github.com/user-attachments/assets/797564d7-a3d7-47cc-997e-84da672c3e12" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
