### PR TITLE
[REFACTOR] 이미지 업로드 용량 제한 증가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -137,6 +137,12 @@ spring:
     activate:
       on-profile: common
 
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB   # 개별 파일의 최대 크기 (10MB로 변경)
+      max-request-size: 20MB # 전체 요청 크기 (20MB로 변경)
+
   mail:
     host: smtp.gmail.com
     port: 587


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #155 

## 📝작업 내용

> 이미지 업로드 시에 용량 제한을 10MB로 늘렸습니다. (후에 QA에서 용량에 대하여 토의하면 좋을 것 같습니다.)

### 스크린샷 (선택)
**8.3MB의 GIF를 올리는데 성공**
<img width="847" alt="스크린샷 2025-02-10 오후 5 26 19" src="https://github.com/user-attachments/assets/c3574c3a-c50b-4be5-9249-bb5dd9e7da2f" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
