### PR TITLE
[FEAT] 프로필 수정 기능 구현

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/user/controller/MyPageController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/controller/MyPageController.java
@@ -1,15 +1,15 @@
 package com.example.bookjourneybackend.domain.user.controller;
 
+import com.example.bookjourneybackend.domain.user.dto.request.PatchUserInfoRequest;
 import com.example.bookjourneybackend.domain.user.dto.response.GetMyPageCalendarResponse;
 import com.example.bookjourneybackend.domain.user.dto.response.GetMyPageUserInfoResponse;
+import com.example.bookjourneybackend.domain.user.dto.response.PatchUserInfoResponse;
 import com.example.bookjourneybackend.domain.user.service.MyPageService;
 import com.example.bookjourneybackend.global.annotation.LoginUserId;
 import com.example.bookjourneybackend.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,6 +40,13 @@ public class MyPageController {
             @LoginUserId final Long userId
     ) {
         return BaseResponse.ok(myPageService.showMyPageUserInfo(userId));
+    }
+
+    @PatchMapping("/profile")
+    public BaseResponse<PatchUserInfoResponse> updateMyPageProfile(
+            @RequestBody final PatchUserInfoRequest patchUserInfoRequest,
+            @LoginUserId final Long userId){
+        return BaseResponse.ok(myPageService.updateMyPageProfile(patchUserInfoRequest,userId));
     }
 
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/user/domain/User.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/domain/User.java
@@ -6,10 +6,7 @@ import com.example.bookjourneybackend.domain.room.domain.Room;
 import com.example.bookjourneybackend.domain.userRoom.domain.UserRoom;
 import com.example.bookjourneybackend.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,9 +30,11 @@ public class User extends BaseEntity{
     @Column(name = "password", nullable = false, length = 255)
     private String password;
 
+    @Setter
     @Column(name = "nickname", nullable = false, length = 60)
     private String nickname;
 
+    @Setter
     @Column(name = "image_url", columnDefinition = "TEXT", nullable = false)
     private String imageUrl;
 

--- a/src/main/java/com/example/bookjourneybackend/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/domain/repository/UserRepository.java
@@ -12,6 +12,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserIdAndStatus(Long userId, EntityStatus status);
     boolean existsByNicknameAndStatus(String nickName, EntityStatus status);
     boolean existsByEmailAndStatus(String nickName, EntityStatus status);
-
-
+    boolean existsByImageUrlAndUserIdNot(String imageUrl, Long userId);
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/user/dto/request/PatchUserInfoRequest.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/dto/request/PatchUserInfoRequest.java
@@ -1,0 +1,15 @@
+package com.example.bookjourneybackend.domain.user.dto.request;
+
+import com.example.bookjourneybackend.domain.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PatchUserInfoRequest {
+
+    private String nickName;
+    private String imageUrl;
+
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/user/dto/response/PatchUserInfoResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/dto/response/PatchUserInfoResponse.java
@@ -1,0 +1,16 @@
+package com.example.bookjourneybackend.domain.user.dto.response;
+
+import com.example.bookjourneybackend.domain.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PatchUserInfoResponse {
+    private String imageUrl;
+    private String nickname;
+
+    public static PatchUserInfoResponse of(User user) {
+        return new PatchUserInfoResponse(user.getImageUrl(), user.getNickname());
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/user/service/MyPageService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/service/MyPageService.java
@@ -112,13 +112,13 @@ public class MyPageService {
                 .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
 
         //프로필 이미지 변경
-        if (!patchUserInfoRequest.getImageUrl().isEmpty()) {
+        if (!patchUserInfoRequest.getImageUrl().isBlank()) {
             if (!userRepository.existsByImageUrlAndUserIdNot(user.getImageUrl(), userId))
                 s3Service.deleteImageFromS3(user.getImageUrl());
             user.setImageUrl(patchUserInfoRequest.getImageUrl());
         }
         //닉네임 변경
-        if(!patchUserInfoRequest.getNickName().isEmpty()){
+        if(!patchUserInfoRequest.getNickName().isBlank()){
             user.setNickname(patchUserInfoRequest.getNickName());
         }
         userRepository.save(user);


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #162 

## 📝작업 내용
<img width="260" alt="image" src="https://github.com/user-attachments/assets/08294b0b-9567-4fc1-a5a9-7b85a4a00c08" />

- 프로필 수정 기능을 구현헀습니다
- 한 화면에서 닉네임/프로필 사진 하나만 변경한다해도 같은 DTO로 넘겨 오기때문에 `.isEmpty()`구문을이용하여 해당하는값만 수정처리했습니다.
- 이미지를 수정할 때, 유저의 기존 이미지 URL과 동일한 이미지 URL를 갖는 유저가있다면 S3에서 해당 이미지를 삭제하지않습니다. 아니라면 S3에서 삭제됩니다.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/55c14366-54e8-4b74-8adc-7583000fa891)
응답도 정상적으로 날라오고, DB에도 정상적으로 반영됩니다
![image](https://github.com/user-attachments/assets/08a752e3-5eeb-4997-b1f6-2c7d4697634a)
필드를 비워서 보낼 경우 기존유저의 해당값이 제대로 반환 되는 것을 확인할 수 있습니다.
