### PR TITLE
[FEAT] 책산책 칭호

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/record/dto/response/PostRecordResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/dto/response/PostRecordResponse.java
@@ -7,12 +7,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class PostRecordResponse {
     private Long recordId;
+    private Integer recordCount;
 
-    public PostRecordResponse(Long recordId) {
+    public PostRecordResponse(Long recordId, Integer recordCount) {
         this.recordId = recordId;
+        this.recordCount = recordCount;
     }
 
-    public static PostRecordResponse of(Long recordId) {
-        return new PostRecordResponse(recordId);
+    public static PostRecordResponse of(Long recordId, Integer recordCount) {
+        return new PostRecordResponse(recordId, recordCount);
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
@@ -79,9 +79,11 @@ public class RecordService {
                 .build();
 
         recordRepository.save(newRecord);
-//        room.addRecord(newRecord);
 
-        return PostRecordResponse.of(newRecord.getRecordId());
+        // 기록 개수 조회
+        int recordCount = userRepository.countRecordsByUserId(userId);
+
+        return PostRecordResponse.of(newRecord.getRecordId(), recordCount);
 
     }
 
@@ -222,7 +224,7 @@ public class RecordService {
 
         Optional<RecordLike> existingLike = recordLikeRepository.findByRecordAndUser(record, user);
 
-        if(existingLike.isPresent()) {
+        if (existingLike.isPresent()) {
             recordLikeRepository.delete(existingLike.get());
             return new PostRecordLikeResponse(false);
         } else {

--- a/src/main/java/com/example/bookjourneybackend/domain/user/controller/MyPageController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/controller/MyPageController.java
@@ -2,6 +2,7 @@ package com.example.bookjourneybackend.domain.user.controller;
 
 import com.example.bookjourneybackend.domain.user.dto.request.PatchUserInfoRequest;
 import com.example.bookjourneybackend.domain.user.dto.response.GetMyPageCalendarResponse;
+import com.example.bookjourneybackend.domain.user.dto.response.GetMyPageCollectorNicknameResponse;
 import com.example.bookjourneybackend.domain.user.dto.response.GetMyPageUserInfoResponse;
 import com.example.bookjourneybackend.domain.user.dto.response.PatchUserInfoResponse;
 import com.example.bookjourneybackend.domain.user.service.MyPageService;
@@ -47,6 +48,13 @@ public class MyPageController {
             @RequestBody final PatchUserInfoRequest patchUserInfoRequest,
             @LoginUserId final Long userId){
         return BaseResponse.ok(myPageService.updateMyPageProfile(patchUserInfoRequest,userId));
+    }
+
+    @GetMapping("/collector-nickname")
+    public BaseResponse<GetMyPageCollectorNicknameResponse> getMyPageRecordCount(
+            @LoginUserId final Long userId
+    ) {
+        return BaseResponse.ok(myPageService.showMyPageRecordCount(userId));
     }
 
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/user/domain/CollectorNicknameType.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/domain/CollectorNicknameType.java
@@ -9,17 +9,17 @@ import java.util.Comparator;
 public enum CollectorNicknameType {
 
     FIRST(1, "책산책 여정 시작"),
-    FIFTIETH(50, "기록 한 걸음"),
-    HUNDREDTH(100, "한 글자 한 글자"),
-    TWO_HUNDREDTH(200, "독서 탐험"),
-    THREE_HUNDREDTH(300, "생각 한 줄"),
-    FOUR_HUNDREDTH(400, "문장 수집"),
-    FIVE_HUNDREDTH(500, "독서 행진"),
-    SIX_HUNDREDTH(600, "감상문의 정석"),
-    SEVEN_HUNDREDTH(700, "기록의 힘"),
-    EIGHT_HUNDREDTH(800, "문장의 완성"),
-    NINE_HUNDREDTH(900, "지식의 창고"),
-    THOUSANDTH(1000, "독서 음유시인");
+    FIFTIETH(5, "기록 한 걸음"),
+    HUNDREDTH(10, "한 글자 한 글자"),
+    TWO_HUNDREDTH(20, "독서 탐험"),
+    THREE_HUNDREDTH(30, "생각 한 줄"),
+    FOUR_HUNDREDTH(40, "문장 수집"),
+    FIVE_HUNDREDTH(50, "독서 행진"),
+    SIX_HUNDREDTH(60, "감상문의 정석"),
+    SEVEN_HUNDREDTH(70, "기록의 힘"),
+    EIGHT_HUNDREDTH(80, "문장의 완성"),
+    NINE_HUNDREDTH(90, "지식의 창고"),
+    THOUSANDTH(100, "독서 음유시인");
 
     private final int threshold;
     private final String collectorNicknameType;

--- a/src/main/java/com/example/bookjourneybackend/domain/user/domain/CollectorNicknameType.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/domain/CollectorNicknameType.java
@@ -1,0 +1,38 @@
+package com.example.bookjourneybackend.domain.user.domain;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+@Getter
+public enum CollectorNicknameType {
+
+    FIRST(1, "책산책 여정 시작"),
+    FIFTIETH(50, "기록 한 걸음"),
+    HUNDREDTH(100, "한 글자 한 글자"),
+    TWO_HUNDREDTH(200, "독서 탐험"),
+    THREE_HUNDREDTH(300, "생각 한 줄"),
+    FOUR_HUNDREDTH(400, "문장 수집"),
+    FIVE_HUNDREDTH(500, "독서 행진"),
+    SIX_HUNDREDTH(600, "감상문의 정석"),
+    SEVEN_HUNDREDTH(700, "기록의 힘"),
+    EIGHT_HUNDREDTH(800, "문장의 완성"),
+    NINE_HUNDREDTH(900, "지식의 창고"),
+    THOUSANDTH(1000, "독서 음유시인");
+
+    private final int threshold;
+    private final String collectorNicknameType;
+
+    CollectorNicknameType(int threshold, String collectorNicknameType) {
+        this.threshold = threshold;
+        this.collectorNicknameType = collectorNicknameType;
+    }
+
+    public static CollectorNicknameType getTitleByRecordCount(int recordCount) {
+        return Arrays.stream(values())
+                .filter(type -> recordCount >= type.threshold)
+                .max(Comparator.comparingInt(type -> type.threshold))
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/domain/repository/UserRepository.java
@@ -3,6 +3,8 @@ package com.example.bookjourneybackend.domain.user.domain.repository;
 import com.example.bookjourneybackend.domain.user.domain.User;
 import com.example.bookjourneybackend.global.entity.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -13,4 +15,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNicknameAndStatus(String nickName, EntityStatus status);
     boolean existsByEmailAndStatus(String nickName, EntityStatus status);
     boolean existsByImageUrlAndUserIdNot(String imageUrl, Long userId);
+
+    @Query("SELECT COUNT(r) FROM Record r WHERE r.user.userId = :userId")
+    int countRecordsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/user/dto/response/GetMyPageCollectorNicknameResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/dto/response/GetMyPageCollectorNicknameResponse.java
@@ -1,0 +1,16 @@
+package com.example.bookjourneybackend.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetMyPageCollectorNicknameResponse {
+
+    private String collectorNickname;
+    private Integer recordCount;
+
+    public static GetMyPageCollectorNicknameResponse of(String collectorNickname, Integer recordCount) {
+        return new GetMyPageCollectorNicknameResponse(collectorNickname, recordCount);
+    }
+}

--- a/src/main/java/com/example/bookjourneybackend/domain/user/service/MyPageService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/service/MyPageService.java
@@ -2,13 +2,11 @@ package com.example.bookjourneybackend.domain.user.service;
 
 import com.example.bookjourneybackend.domain.book.domain.Book;
 import com.example.bookjourneybackend.domain.room.domain.Room;
+import com.example.bookjourneybackend.domain.user.domain.CollectorNicknameType;
 import com.example.bookjourneybackend.domain.user.domain.User;
 import com.example.bookjourneybackend.domain.user.domain.repository.UserRepository;
 import com.example.bookjourneybackend.domain.user.dto.request.PatchUserInfoRequest;
-import com.example.bookjourneybackend.domain.user.dto.response.CalendarData;
-import com.example.bookjourneybackend.domain.user.dto.response.GetMyPageCalendarResponse;
-import com.example.bookjourneybackend.domain.user.dto.response.GetMyPageUserInfoResponse;
-import com.example.bookjourneybackend.domain.user.dto.response.PatchUserInfoResponse;
+import com.example.bookjourneybackend.domain.user.dto.response.*;
 import com.example.bookjourneybackend.domain.userRoom.domain.repository.UserRoomRepository;
 import com.example.bookjourneybackend.global.exception.GlobalException;
 import com.example.bookjourneybackend.global.util.DateUtil;
@@ -106,7 +104,7 @@ public class MyPageService {
      * 닉네임 변경 -> 닉네임 변경
      */
     @Transactional
-    public PatchUserInfoResponse updateMyPageProfile(PatchUserInfoRequest patchUserInfoRequest,Long userId) {
+    public PatchUserInfoResponse updateMyPageProfile(PatchUserInfoRequest patchUserInfoRequest, Long userId) {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
@@ -118,11 +116,26 @@ public class MyPageService {
             user.setImageUrl(patchUserInfoRequest.getImageUrl());
         }
         //닉네임 변경
-        if(!patchUserInfoRequest.getNickName().isBlank()){
+        if (!patchUserInfoRequest.getNickName().isBlank()) {
             user.setNickname(patchUserInfoRequest.getNickName());
         }
         userRepository.save(user);
 
         return PatchUserInfoResponse.of(user);
     }
+
+    /**
+     * 사용자의 기록 개수를 조회하고, 해당 개수에 맞는 칭호를 반환
+     */
+    @Transactional(readOnly = true)
+    public GetMyPageCollectorNicknameResponse showMyPageRecordCount(Long userId) {
+
+        int recordCount = userRepository.countRecordsByUserId(userId);
+
+        CollectorNicknameType collectorNicknameType = CollectorNicknameType.getTitleByRecordCount(recordCount);
+        String collectorNickname = (collectorNicknameType != null) ? collectorNicknameType.getCollectorNicknameType() : "칭호 없음";
+
+        return GetMyPageCollectorNicknameResponse.of(collectorNickname, recordCount);
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #149 

## 📝작업 내용

- 기록을 남긴 개수에 따라서 칭호를 부여합니다
- 기록을 등록하자마자 바텀시트가 뜰 수 있도록 기록을 등록하면 기록 개수를 반환하도록 코드를 수정했습니다

### 스크린샷 (선택)

- 칭호 불러오기
<img width="760" alt="스크린샷 2025-02-12 오후 4 21 54" src="https://github.com/user-attachments/assets/1c7be6c3-e8ca-4b79-8125-8cdfaa73958e" />

- 기록 등록하면 개수 반환
<img width="607" alt="스크린샷 2025-02-12 오후 4 22 34" src="https://github.com/user-attachments/assets/2add2404-cd59-4245-841b-39ad6127b166" />

- 기록 등록하고 칭호 수정된 모습
<img width="686" alt="스크린샷 2025-02-12 오후 4 22 43" src="https://github.com/user-attachments/assets/df6505bf-b51a-4a21-947e-0996b0597fc0" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
