### PR TITLE
[FIX] 독서기록장 api에 로그인된 사용자의 닉네임 반환 추가

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/room/dto/response/GetRoomArchiveResponse.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/dto/response/GetRoomArchiveResponse.java
@@ -9,13 +9,15 @@ import java.util.List;
 @NoArgsConstructor
 public class GetRoomArchiveResponse {
 
+    private String nickName;
     private List<RecordInfo> recordList;
 
-    public GetRoomArchiveResponse(List<RecordInfo> recordList) {
+    public GetRoomArchiveResponse(String nickName, List<RecordInfo> recordList) {
+        this.nickName = nickName;
         this.recordList = recordList;
     }
 
-    public static GetRoomArchiveResponse of(List<RecordInfo> recordList) {
-        return new GetRoomArchiveResponse(recordList);
+    public static GetRoomArchiveResponse of(String nickName, List<RecordInfo> recordList) {
+        return new GetRoomArchiveResponse(nickName, recordList);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #175 

## 📝작업 내용

> 독서기록장 api 2개 모두 로그인된 사용자의 닉네임을 반환하도록 수정하였습니다.
<img width="373" alt="스크린샷 2025-02-12 오후 4 40 39" src="https://github.com/user-attachments/assets/0fb45f94-5587-4087-8bcb-28379cab53ce" />


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
