### PR TITLE
[FEAT] 기록 삭제

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/record/controller/RecordController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/controller/RecordController.java
@@ -65,4 +65,14 @@ public class RecordController {
         return BaseResponse.ok(recordService.enterRecordPage(roomId, userId, currentPage));
     }
 
+    @DeleteMapping("/{recordId}")
+    public BaseResponse<Void> deleteRecord(
+            @PathVariable("recordId") final Long recordId,
+            @LoginUserId final Long userId
+    ) {
+        recordService.deleteRecord(recordId, userId);
+        return BaseResponse.ok();
+    }
+
 }
+

--- a/src/main/java/com/example/bookjourneybackend/domain/record/domain/repository/RecordRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/domain/repository/RecordRepository.java
@@ -25,4 +25,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
     Optional<List<Record>> findRecordsOrderByPage(@Param("roomId") Long roomId, @Param("sortType") RecordSortType sortType);
 
     void deleteAllByRoomAndUser(Room room, User user);
+
+    void deleteByRecordId(Long recordId);
 }
+

--- a/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
@@ -22,6 +22,7 @@ import com.example.bookjourneybackend.domain.userRoom.domain.repository.UserRoom
 import com.example.bookjourneybackend.global.exception.GlobalException;
 import com.example.bookjourneybackend.global.util.DateUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,6 +39,7 @@ import java.util.stream.Collectors;
 import static com.example.bookjourneybackend.domain.record.domain.RecordSortType.LATEST;
 import static com.example.bookjourneybackend.global.response.status.BaseExceptionResponseStatus.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RecordService {
@@ -286,4 +288,26 @@ public class RecordService {
 
         return PostRecordPageResponse.of(currentPage);
     }
+
+    /**
+     * 기록 삭제
+     */
+    @Transactional
+    public void deleteRecord(Long recordId, Long userId) {
+        // 기록 조회
+        Record record = recordRepository.findById(recordId)
+                .orElseThrow(() -> new GlobalException(CANNOT_FOUND_RECORD));
+
+        log.info(String.valueOf(userId));
+        log.info(String.valueOf(record.getUser().getUserId()));
+
+        // 기록 작성자가 아닌 경우 삭제 불가능
+        if (!record.getUser().getUserId().equals(userId)) {
+            throw new GlobalException(UNAUTHORIZED_DELETE_RECORD);
+        }
+
+        // 기록 삭제
+        recordRepository.deleteByRecordId(recordId);
+    }
 }
+

--- a/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
@@ -299,13 +299,18 @@ public class RecordService {
         // 기록 조회
         Record record = recordRepository.findById(recordId)
                 .orElseThrow(() -> new GlobalException(CANNOT_FOUND_RECORD));
-
-        log.info(String.valueOf(userId));
-        log.info(String.valueOf(record.getUser().getUserId()));
+        Room room = record.getRoom();
+        User user = userRepository.findById(userId).orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER));
+        UserRoom userRoom = userRoomRepository.findUserRoomByRoomAndUser(room, user).orElseThrow(() -> new GlobalException(CANNOT_FOUND_USER_ROOM));
 
         // 기록 작성자가 아닌 경우 삭제 불가능
         if (!record.getUser().getUserId().equals(userId)) {
             throw new GlobalException(UNAUTHORIZED_DELETE_RECORD);
+        }
+
+        // 방이 expired 상태이면 기록 삭제 불가능
+        if (userRoom.getStatus() == EXPIRED) {
+            throw new GlobalException(CANNOT_DELETE_IN_EXPIRED_ROOM);
         }
 
         // 기록 삭제

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -97,6 +97,8 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     ROOM_IS_ALONE(8012, BAD_REQUEST, "혼자읽기 방입니다."),
     CANNOT_FIND_HOST(8012, BAD_REQUEST, "호스트를 찾을 수 없습니다."),
 
+    CANNOT_DELETE_IN_EXPIRED_ROOM(8009, BAD_REQUEST, "기간이 지난 방에는 삭제할 수 없습니다."),
+
     /**
      * 9000 : record 관련
      */

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -27,6 +27,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     CANNOT_CREATE_EMAIL_AUTH_CODE(5005, BAD_REQUEST, "인증번호를 발급 받지 않은 이메일입니다. 먼저 인증번호를 발급받아주세요."),
     EMAIL_AUTH_CODE_EXPIRED(5006, BAD_REQUEST, "만료된 인증번호 입니다."),
     NO_SUCH_ALGORITHM(5007, BAD_REQUEST, "지정된 난수 생성 알고리즘을 찾을 수 없습니다."),
+    PASSWORD_NOT_EQUAL(5008, BAD_REQUEST, "현재 비밀번호와 일치하지 않습니다. 다시 입력해주세요."),
 
     /**
      * 5100 : image 관련
@@ -108,6 +109,8 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
 
     INVALID_RECORD_SORT_TYPE(9003, BAD_REQUEST, "알맞은 기록 나열 타입을 찾을 수 없습니다."),
 
+    UNAUTHORIZED_DELETE_RECORD(9004, BAD_REQUEST, "기록 작성자가 아닌 경우 기록을 삭제할 수 없습니다."),
+
     /**
      * 10000 : recentSearch 관련
      */
@@ -151,3 +154,4 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
         return message;
     }
 }
+


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #181 

## 📝작업 내용

- 기록 삭제를 구현했습니다
- 사용자가 작성한 기록이 아니면 삭제하지 못합니다
- 좋아요, 댓글은 연관관계로 묶여있기 때문에 자동삭제됩니다

### 스크린샷 (선택)

- 정상 삭제

<img width="737" alt="스크린샷 2025-02-13 오후 9 01 32" src="https://github.com/user-attachments/assets/22fff866-cfd0-4a83-964c-41f57e6acdfa" />


- 기록 작성자가 아닌 경우
<img width="745" alt="스크린샷 2025-02-13 오후 8 53 46" src="https://github.com/user-attachments/assets/26cbff7c-b5ab-4fb9-b578-f5dc72205f08" />

- db에서 잘 삭제되는거 확인했습니다
<img width="929" alt="스크린샷 2025-02-13 오후 9 01 53" src="https://github.com/user-attachments/assets/72d1db75-65b3-4dd3-aeb8-661e00842c93" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
