### PR TITLE
[FEAT] 댓글 삭제

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/comment/controller/CommentController.java
@@ -46,4 +46,13 @@ public class CommentController {
     ) {
         return BaseResponse.ok(commentService.toggleCommentLike(commentId, userId));
     }
+
+    @DeleteMapping("/{commentId}")
+    public BaseResponse<Void> deleteComment(
+            @PathVariable("commentId") final Long commentId,
+            @LoginUserId final Long userId
+    ) {
+        commentService.deleteComment(commentId, userId);
+        return BaseResponse.ok();
+    }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/comment/service/CommentService.java
@@ -45,6 +45,10 @@ public class CommentService {
     private final RecordLikeRepository recordLikeRepository;
     private final DateUtil dateUtil;
 
+    /**
+     * 댓글 조회
+     * 기록과 기록에 달린 댓글들을 한번에 조회합니다
+     */
     @Transactional(readOnly = true)
     public GetCommentListResponse showComments(Long recordId, Long userId) {
         Record record = recordRepository.findById(recordId).orElseThrow(() -> new GlobalException(CANNOT_FOUND_RECORD));
@@ -90,6 +94,9 @@ public class CommentService {
         return GetCommentListResponse.of(commentList, recordInfo);
     }
 
+    /**
+     * 댓글 달기
+     */
     @Transactional
     public PostCommentResponse createComment(Long recordId, Long userId, PostCommentRequest request) {
         Record record = recordRepository.findById(recordId).orElseThrow(() -> new GlobalException(CANNOT_FOUND_RECORD));
@@ -113,6 +120,9 @@ public class CommentService {
         return PostCommentResponse.of(newComment.getCommentId());
     }
 
+    /**
+     * 댓글 좋아요
+     */
     @Transactional
     public PostCommentLikeResponse toggleCommentLike(Long commentId, Long userId) {
         Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new GlobalException(CANNOT_FOUND_COMMENT));
@@ -146,5 +156,20 @@ public class CommentService {
             commentLikeRepository.flush(); // 즉시 db에 반영
             return new PostCommentLikeResponse(true);
         }
+    }
+
+    /**
+     * 댓글 삭제
+     */
+    @Transactional
+    public void deleteComment(Long commentId, Long userId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new GlobalException(CANNOT_FOUND_COMMENT));
+
+        // 댓글 작성자가 아닌 경우 삭제 불가능
+        if(!comment.getUser().getUserId().equals(userId)) {
+            throw new GlobalException(UNAUTHORIZED_DELETE_COMMENT);
+        }
+
+        commentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -127,6 +127,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
      * 12000 : comment 관련
      */
     CANNOT_FOUND_COMMENT(12001, BAD_REQUEST, "댓글을 찾을 수 없습니다."),
+    UNAUTHORIZED_DELETE_COMMENT(12002, BAD_REQUEST, "댓글 작성자가 아닌 경우 기록을 삭제할 수 없습니다."),
 
     /**
      * 13000 : mypage 관련

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -97,6 +97,8 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     ROOM_IS_ALONE(8012, BAD_REQUEST, "혼자읽기 방입니다."),
     CANNOT_FIND_HOST(8012, BAD_REQUEST, "호스트를 찾을 수 없습니다."),
 
+    CANNOT_DELETE_IN_EXPIRED_ROOM(8009, BAD_REQUEST, "기간이 지난 방에는 삭제할 수 없습니다."),
+
     /**
      * 9000 : record 관련
      */


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #180 

## 📝작업 내용

- 댓글 삭제를 구현했습니다
- 댓글 작성자가 아니면 댓글을 삭제하지 못합니다

### 스크린샷 (선택)

- 잘 삭제되는 모습
<img width="1392" alt="스크린샷 2025-02-15 오후 3 19 39" src="https://github.com/user-attachments/assets/4e3dde8d-3422-40b0-aa7a-e171b7687371" />

- 댓글 작성자 아니면 삭제 못함
<img width="1392" alt="스크린샷 2025-02-15 오후 3 20 22" src="https://github.com/user-attachments/assets/892677b4-4c72-46b9-b634-4d957334cf8d" />


- db에서 댓글 삭제되는거 확인했습니다
<img width="1146" alt="스크린샷 2025-02-15 오후 2 54 54" src="https://github.com/user-attachments/assets/22c6ca0c-aaea-4e92-a6d9-711d3b364490" />
<img width="1165" alt="스크린샷 2025-02-15 오후 3 19 56" src="https://github.com/user-attachments/assets/ed41e7de-1531-4856-be5c-e8583573ebca" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
