### PR TITLE
[TEST] Book 관련 테스트코드 작성

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/book/domain/Book.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/domain/Book.java
@@ -27,7 +27,7 @@ public class Book extends BaseEntity {
     @Column(nullable = false)
     private GenreType genre;
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false)
     private String bookTitle;
 
     @Column(length = 255)

--- a/src/main/java/com/example/bookjourneybackend/domain/book/service/BookCacheService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/service/BookCacheService.java
@@ -5,7 +5,6 @@ import com.example.bookjourneybackend.domain.book.dto.request.GetBookListRequest
 import com.example.bookjourneybackend.domain.book.dto.response.GetBookInfoResponse;
 import com.example.bookjourneybackend.global.exception.GlobalException;
 import com.example.bookjourneybackend.global.util.AladinApiUtil;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -20,7 +19,6 @@ public class BookCacheService {
 
     private final RestTemplate restTemplate;
     private final AladinApiUtil aladinApiUtil;
-    private final ObjectMapper objectMapper;
 
     //Ex) books:searchTerm:해리포터(인코딩 안된상태로 들어감):genreType:NOVEL_POETRY_DRAMA:queryType:Title:page:1
     @Cacheable(

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/service/RecentSearchService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/service/RecentSearchService.java
@@ -138,5 +138,6 @@ public class RecentSearchService {
                 .build();
 
         recentSearchRepository.save(newRecentSearch);
+        recentSearchRepository.flush();
     }
 }

--- a/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/service/RecordService.java
@@ -71,6 +71,14 @@ public class RecordService {
         RecordType recordType = RecordType.from(postRecordRequest.getRecordType());
         validateRecordRequest(postRecordRequest, recordType);
 
+        Book book = room.getBook();
+        int totalPages = book.getPageCount();
+
+        //  페이지 기록일 때 입력한 페이지 가 책의 페이지 수보다 크면 오류 발생
+        if (recordType == RecordType.PAGE && postRecordRequest.getRecordPage() > totalPages) {
+            throw new GlobalException(INVALID_PAGE_NUMBER);
+        }
+
         Record newRecord = Record.builder()
                 .room(room)
                 .user(user)

--- a/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/userRoom/domain/repository/UserRoomRepository.java
@@ -43,11 +43,11 @@ public interface UserRoomRepository extends JpaRepository<UserRoom, Long> {
             "AND r.roomType = 'TOGETHER'")
    List<UserRoom> findInActiveTogetherRoomsByUserIdAndDate(@Param("userId") Long userId, @Param("year") Integer year, @Param("month") Integer month, @Param("status") EntityStatus status);
 
-    @Query("SELECT ur FROM UserRoom ur " +
+     @Query("SELECT ur FROM UserRoom ur " +
             "JOIN FETCH ur.room r " +
             "WHERE ur.user.userId = :userId AND ur.status = :status " +
             "AND ((:month IS NULL OR MONTH(r.startDate) <= :month) AND YEAR(r.startDate) <= :year) " +
-            "AND (r.progressEndDate IS NULL OR (MONTH(r.progressEndDate) >= :month AND YEAR(r.progressEndDate) >= :year)) " +
+            "AND (r.progressEndDate IS NULL OR ((:month IS NULL OR MONTH(r.progressEndDate) >= :month) AND YEAR(r.progressEndDate) >= :year)) " +
             "AND r.roomType = 'ALONE'")
     List<UserRoom> findInActiveAloneRoomsByUserIdAndDate(@Param("userId") Long userId, @Param("year") Integer year, @Param("month") Integer month, @Param("status") EntityStatus status);
 

--- a/src/main/java/com/example/bookjourneybackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/bookjourneybackend/global/config/SecurityConfig.java
@@ -31,13 +31,9 @@ public class SecurityConfig {
     private static final String[] AUTH_WHITELIST = {
             "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
             "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html","/swagger-ui/index.html",
-            "/auth/login","/auth/reissue",
-            "/users/signup","/users/emails/verification-requests","/users/emails/verifications",
-            "/users/nickname","/h2-console/**"
-
-            , "/books/**", "/rooms/**", "/users/**","/**"    //개발을 위해 일시적으로 허용..,
+            "/auth/login", "/users/signup","/users/emails/vertifications-requests","/users/emails/vertifications",
+            "/users/nickname","/users/images","/h2-console/**"
     };
-
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
@@ -76,9 +72,9 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(Arrays.asList(
                 "http://localhost:5173",  // 로컬 환경
-                "http://ec2-13-48-61-179.eu-north-1.compute.amazonaws.com",  // 서버 배포 환경
+                "http://ec2-13-48-61-179.eu-north-1.compute.amazonaws.com",  // http 배포 환경
                 "https://book-journey-two.vercel.app", //프엔 배포 환경
-                "https://book-journey.click"
+                "https://book-journey.click" //https 배포 환경
         ));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PATCH", "DELETE","PUT","OPTIONS"));  // 허용할 HTTP 메서드 설정
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type","Refresh-Token"));  // 허용할 헤더 설정

--- a/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/bookjourneybackend/global/response/status/BaseExceptionResponseStatus.java
@@ -131,7 +131,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
      * 12000 : comment 관련
      */
     CANNOT_FOUND_COMMENT(12001, BAD_REQUEST, "댓글을 찾을 수 없습니다."),
-    UNAUTHORIZED_DELETE_COMMENT(12002, BAD_REQUEST, "댓글 작성자가 아닌 경우 기록을 삭제할 수 없습니다."),
+    UNAUTHORIZED_DELETE_COMMENT(12002, BAD_REQUEST, "댓글 작성자가 아닌 경우 댓글을 삭제할 수 없습니다."),
 
     /**
      * 13000 : mypage 관련

--- a/src/test/java/com/example/bookjourneybackend/domain/book/service/BookSearchTest.java
+++ b/src/test/java/com/example/bookjourneybackend/domain/book/service/BookSearchTest.java
@@ -1,0 +1,98 @@
+package com.example.bookjourneybackend.domain.book.service;
+
+import com.example.bookjourneybackend.domain.book.domain.repository.BookRepository;
+import com.example.bookjourneybackend.domain.book.dto.request.GetBookListRequest;
+import com.example.bookjourneybackend.domain.book.dto.response.GetBookInfoResponse;
+import com.example.bookjourneybackend.domain.book.dto.response.GetBookListResponse;
+import com.example.bookjourneybackend.domain.favorite.domain.repository.FavoriteRepository;
+import com.example.bookjourneybackend.domain.recentSearch.service.RecentSearchService;
+import com.example.bookjourneybackend.domain.user.domain.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static com.example.bookjourneybackend.domain.book.domain.GenreType.NOVEL_POETRY_DRAMA;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BookSearchTest {
+
+    @InjectMocks
+    private BookService bookService;
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private FavoriteRepository favoriteRepository;
+
+    @Mock
+    private BookCacheService bookCacheService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RecentSearchService recentSearchService;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void beforeEach() {
+        objectMapper = new ObjectMapper();
+        bookService = new BookService(bookRepository, favoriteRepository, objectMapper, bookCacheService, userRepository, recentSearchService);
+    }
+
+    @Test
+    @DisplayName("알라딘 api를 통해 책 검색을 했을 때 10개의 책이 반환되고, 캐싱이 올바르게 되고 있는지 테스트")
+    void test_searchBook() {
+        // given
+        Long userId = 1L;
+        GetBookListRequest request = GetBookListRequest.builder()
+                .searchTerm("해리포터")
+                .genre(NOVEL_POETRY_DRAMA)
+                .queryType("Title")
+                .page(1)
+                .build();
+
+        String currentResponse = "{ \"version\" : \"20070901\", \"title\" : \"알라딘 검색결과 - 해리포터\", \"link\" : \"http:\\/\\/www.aladin.co.kr\\/search\\/wsearchresult.aspx?KeyTitle=%c7%d8%b8%ae%c6%f7%c5%cd&amp;SearchTarget=book\", \"pubDate\" : \"Sat, 15 Feb 2025 09:00:22 GMT\", \"imageUrl\" : \"http:\\/\\/www.aladin.co.kr\\/ucl_editor\\/img_secur\\/header\\/2010\\/logo.jpg\", \"totalResults\" : 357, \"startIndex\" : 1, \"itemsPerPage\" : 10, \"query\" : \"해리포터\", \"searchCategoryId\" : 1, \"searchCategoryName\" : \"국내도서&gt;소설/시/희곡\", \"item\" : [  { \"title\" : \"해리 포터와 불의 잔 2 (양장)\", \"link\" : \"http:\\/\\/www.aladin.co.kr\\/shop\\/wproduct.aspx?ItemId=357750553&amp;copyPaper=1&amp;ttbkey=ttbbuzz033122112002&amp;start=api\", \"author\" : \"J.K. 롤링 지음, 강동혁 옮김\", \"pubDate\" : \"2025-02-26\", \"description\" : \"이번에 출간하는 《해리 포터》 시리즈는 지난 2019년에 새로운 번역을 선보인 버전이다.  J.K. 롤링이 작품 속에 이룩해놓은 문학적 성취가 완벽하게 구현되어 있다. 복선과 반전을 선사하는 문학적 장치들을 보다 정교하고 세련되게 다듬었으며, 인물들 사이의 관계나 그들의 숨겨진 비밀 그리고 성격이 도드라지는 말투의 미세한 뉘앙스까지 점검했다.\", \"creator\" : \"aladin\", \"isbn\" : \"K232036847\", \"isbn13\" : \"9791193790694\", \"itemId\" : 357750553, \"priceSales\" : 23850, \"priceStandard\" : 26500, \"stockStatus\" : \"예약판매\", \"mileage\" : 1320, \"cover\":\"https:\\/\\/image.aladin.co.kr\\/product\\/35775\\/5\\/cover150\\/k232036847_1.jpg\", \"categoryId\" : 51120, \"categoryName\" : \"국내도서>소설/시/희곡>판타지/환상문학>외국판타지/환상소설\", \"publisher\":\"문학수첩\", \"customerReviewRank\":0  } , { \"title\" : \"해리 포터와 불의 잔 1 (양장)\", \"link\" : \"http:\\/\\/www.aladin.co.kr\\/shop\\/wproduct.aspx?ItemId=357749531&amp;copyPaper=1&amp;ttbkey=ttbbuzz033122112002&amp;start=api\", \"author\" : \"J.K. 롤링 지음, 강동혁 옮김\", \"pubDate\" : \"2025-02-26\", \"description\" : \"이번에 출간하는 《해리 포터》 시리즈는 지난 2019년에 새로운 번역을 선보인 버전이다.  J.K. 롤링이 작품 속에 이룩해놓은 문학적 성취가 완벽하게 구현되어 있다. 복선과 반전을 선사하는 문학적 장치들을 보다 정교하고 세련되게 다듬었으며, 인물들 사이의 관계나 그들의 숨겨진 비밀 그리고 성격이 도드라지는 말투의 미세한 뉘앙스까지 점검했다.\", \"creator\" : \"aladin\", \"isbn\" : \"K062036847\", \"isbn13\" : \"9791193790687\", \"itemId\" : 357749531, \"priceSales\" : 23850, \"priceStandard\" : 26500, \"stockStatus\" : \"예약판매\", \"mileage\" : 1320, \"cover\":\"https:\\/\\/image.aladin.co.kr\\/product\\/35774\\/95\\/cover150\\/k062036847_1.jpg\", \"categoryId\" : 51120, \"categoryName\" : \"국내도서>소설/시/희곡>판타지/환상문학>외국판타지/환상소설\", \"publisher\":\"문학수첩\", \"customerReviewRank\":0  } , { \"title\" : \"해리 포터와 아즈카반의 죄수 (양장)\", \"link\" : \"http:\\/\\/www.aladin.co.kr\\/shop\\/wproduct.aspx?ItemId=356288081&amp;copyPaper=1&amp;ttbkey=ttbbuzz033122112002&amp;start=api\", \"author\" : \"J.K. 롤링 지음, 강동혁 옮김\", \"pubDate\" : \"2025-02-11\", \"description\" : \"여느 때처럼 괴로운 여름방학을 보내던 해리는 심한 모욕을 받고 화가 난 나머지, 더즐리 이모부의 여동생에게 무단으로 마법을 건다. 집을 뛰쳐나온 해리는 퇴학당할지도 모른다는 생각에 상심하지만, 그를 기다리는 건 더 큰 문제다. 바로 12년 동안 아즈카반이라는 마법사 감옥에 수감되어 있던 악명 높은 살인자, 시리우스 블랙이 탈옥해 해리를 노린다는 소식이다.\", \"creator\" : \"aladin\", \"isbn\" : \"K572036390\", \"isbn13\" : \"9791193790670\", \"itemId\" : 356288081, \"priceSales\" : 24750, \"priceStandard\" : 27500, \"stockStatus\" : \"\", \"mileage\" : 1370, \"cover\":\"https:\\/\\/image.aladin.co.kr\\/product\\/35628\\/80\\/cover150\\/k572036390_1.jpg\", \"categoryId\" : 51120, \"categoryName\" : \"국내도서>소설/시/희곡>판타지/환상문학>외국판타지/환상소설\", \"publisher\":\"문학수첩\", \"customerReviewRank\":0  } , { \"title\" : \"해리 포터와 비밀의 방 (양장)\", \"link\" : \"http:\\/\\/www.aladin.co.kr\\/shop\\/wproduct.aspx?ItemId=354930732&amp;copyPaper=1&amp;ttbkey=ttbbuzz033122112002&amp;start=api\", \"author\" : \"J.K. 롤링 지음, 강동혁 옮김\", \"pubDate\" : \"2025-01-14\", \"description\" : \"\", \"creator\" : \"aladin\", \"isbn\" : \"K562035555\", \"isbn13\" : \"9791193790663\", \"itemId\" : 354930732, \"priceSales\" : 23850, \"priceStandard\" : 26500, \"stockStatus\" : \"\", \"mileage\" : 1320, \"cover\":\"https:\\/\\/image.aladin.co.kr\\/product\\/35493\\/7\\/cover150\\/k562035555_1.jpg\", \"categoryId\" : 51120, \"categoryName\" : \"국내도서>소설/시/희곡>판타지/환상문학>외국판타지/환상소설\", \"publisher\":\"문학수첩\", \"customerReviewRank\":0  } , { \"title\" : \"해리 포터와 마법사의 돌 (양장)\", \"link\" : \"http:\\/\\/www.aladin.co.kr\\/shop\\/wproduct.aspx?ItemId=354930529&amp;copyPaper=1&amp;ttbkey=ttbbuzz033122112002&amp;start=api\", \"author\" : \"J.K. 롤링 지음, 강동혁 옮김\", \"pubDate\" : \"2025-01-14\", \"description\" : \"1997년 영국에서 출간된 이래 《해리 포터》 시리즈는 지금까지 200개국 이상 80개의 언어로 번역되고 출간되어 5억 부 이상을 판매했다. 이번에 출간하는 《해리 포터》 시리즈는 지난 2019년에 새로운 번역을 선보인 버전이다.\", \"creator\" : \"aladin\", \"isbn\" : \"K412035555\", \"isbn13\" : \"9791193790656\", \"itemId\" : 354930529, \"priceSales\" : 23850, \"priceStandard\" : 26500, \"stockStatus\" : \"\", \"mileage\" : 1320, \"cover\":\"https:\\/\\/image.aladin.co.kr\\/product\\/35493\\/5\\/cover150\\/k412035555_1.jpg\", \"categoryId\" : 51120, \"categoryName\" : \"국내도서>소설/시/희곡>판타지/환상문학>외국판타지/환상소설\", \"publisher\":\"문학수첩\", \"customerReviewRank\":0  } , { \"title\" : \"해리 포터와 죽음의 성물 4 (무선)\", \"link\" : \"http:\\/\\/www.aladin.co.kr\\/shop\\/wproduct.aspx?ItemId=352558700&amp;copyPaper=1&amp;ttbkey=ttbbuzz033122112002&amp;start=api\", \"author\" : \"J.K. 롤링 지음, 강동혁 옮김\", \"pubDate\" : \"2024-11-27\", \"description\" : \"이번에 출간하는 《해리 포터》 시리즈는 지난 2019년에 새로운 번역을 선보인 버전이다. 7권 《해리 포터와 죽음의 성물》로 완간된 기존의 《해리 포터》 시리즈는 빈틈없는 소설적 구성과 생생한 캐릭터 그리고 마법 세계를 정교하게 묘사하며 풍부한 상상력이 돋보이면서도 정밀한 세계관을 구축했다.\", \"creator\" : \"aladin\", \"isbn\" : \"K812934145\", \"isbn13\" : \"9791193790632\", \"itemId\" : 352558700, \"priceSales\" : 11700, \"priceStandard\" : 13000, \"stockStatus\" : \"\", \"mileage\" : 650, \"cover\":\"https:\\/\\/image.aladin.co.kr\\/product\\/35255\\/87\\/cover150\\/k812934145_1.jpg\", \"categoryId\" : 51120, \"categoryName\" : \"국내도서>소설/시/희곡>판타지/환상문학>외국판타지/환상소설\", \"publisher\":\"문학수첩\", \"customerReviewRank\":0  } , { \"title\" : \"해리 포터와 죽음의 성물 3 (무선)\", \"link\" : \"http:\\/\\/www.aladin.co.kr\\/shop\\/wproduct.aspx?ItemId=352558655&amp;copyPaper=1&amp;ttbkey=ttbbuzz033122112002&amp;start=api\", \"author\" : \"J.K. 롤링 지음, 강동혁 옮김\", \"pubDate\" : \"2024-11-27\", \"description\" : \"이번에 출간하는 《해리 포터》 시리즈는 지난 2019년에 새로운 번역을 선보인 버전이다. 7권 《해리 포터와 죽음의 성물》로 완간된 기존의 《해리 포터》 시리즈는 빈틈없는 소설적 구성과 생생한 캐릭터 그리고 마법 세계를 정교하게 묘사하며 풍부한 상상력이 돋보이면서도 정밀한 세계관을 구축했다.\", \"creator\" : \"aladin\", \"isbn\" : \"K872934145\", \"isbn13\" : \"9791193790625\", \"itemId\" : 352558655, \"priceSales\" : 11700, \"priceStandard\" : 13000, \"stockStatus\" : \"\", \"mileage\" : 650, \"cover\":\"https:\\/\\/image.aladin.co.kr\\/product\\/35255\\/86\\/cover150\\/k872934145_1.jpg\", \"categoryId\" : 51120, \"categoryName\" : \"국내도서>소설/시/희곡>판타지/환상문학>외국판타지/환상소설\", \"publisher\":\"문학수첩\", \"customerReviewRank\":0  } , { \"title\" : \"해리 포터와 죽음의 성물 2 (무선)\", \"link\" : \"http:\\/\\/www.aladin.co.kr\\/shop\\/wproduct.aspx?ItemId=352558625&amp;copyPaper=1&amp;ttbkey=ttbbuzz033122112002&amp;start=api\", \"author\" : \"J.K. 롤링 지음, 강동혁 옮김\", \"pubDate\" : \"2024-11-27\", \"description\" : \"이번에 출간하는 《해리 포터》 시리즈는 지난 2019년에 새로운 번역을 선보인 버전이다. 7권 《해리 포터와 죽음의 성물》로 완간된 기존의 《해리 포터》 시리즈는 빈틈없는 소설적 구성과 생생한 캐릭터 그리고 마법 세계를 정교하게 묘사하며 풍부한 상상력이 돋보이면서도 정밀한 세계관을 구축했다.\", \"creator\" : \"aladin\", \"isbn\" : \"K822934145\", \"isbn13\" : \"9791193790618\", \"itemId\" : 352558625, \"priceSales\" : 11700, \"priceStandard\" : 13000, \"stockStatus\" : \"\", \"mileage\" : 650, \"cover\":\"https:\\/\\/image.aladin.co.kr\\/product\\/35255\\/86\\/cover150\\/k822934145_1.jpg\", \"categoryId\" : 51120, \"categoryName\" : \"국내도서>소설/시/희곡>판타지/환상문학>외국판타지/환상소설\", \"publisher\":\"문학수첩\", \"customerReviewRank\":0  } , { \"title\" : \"해리 포터와 죽음의 성물 1 (무선)\", \"link\" : \"http:\\/\\/www.aladin.co.kr\\/shop\\/wproduct.aspx?ItemId=352558507&amp;copyPaper=1&amp;ttbkey=ttbbuzz033122112002&amp;start=api\", \"author\" : \"J.K. 롤링 지음, 강동혁 옮김\", \"pubDate\" : \"2024-11-27\", \"description\" : \"이번에 출간하는 《해리 포터》 시리즈는 지난 2019년에 새로운 번역을 선보인 버전이다. 7권 《해리 포터와 죽음의 성물》로 완간된 기존의 《해리 포터》 시리즈는 빈틈없는 소설적 구성과 생생한 캐릭터 그리고 마법 세계를 정교하게 묘사하며 풍부한 상상력이 돋보이면서도 정밀한 세계관을 구축했다.\", \"creator\" : \"aladin\", \"isbn\" : \"K732934145\", \"isbn13\" : \"9791193790601\", \"itemId\" : 352558507, \"priceSales\" : 11700, \"priceStandard\" : 13000, \"stockStatus\" : \"\", \"mileage\" : 650, \"cover\":\"https:\\/\\/image.aladin.co.kr\\/product\\/35255\\/85\\/cover150\\/k732934145_1.jpg\", \"categoryId\" : 51120, \"categoryName\" : \"국내도서>소설/시/희곡>판타지/환상문학>외국판타지/환상소설\", \"publisher\":\"문학수첩\", \"customerReviewRank\":0  } , { \"title\" : \"해리 포터와 혼혈 왕자 4 (무선)\", \"link\" : \"http:\\/\\/www.aladin.co.kr\\/shop\\/wproduct.aspx?ItemId=352558345&amp;copyPaper=1&amp;ttbkey=ttbbuzz033122112002&amp;start=api\", \"author\" : \"J.K. 롤링 지음, 강동혁 옮김\", \"pubDate\" : \"2024-11-27\", \"description\" : \"1997년 영국에서 출간된 이래 《해리 포터》 시리즈는 지금까지 200개국 이상 80개의 언어로 번역되고 출간되어 5억 부 이상을 판매했다. 국내에서도 1999년 《해리 포터와 마법사의 돌》의 출간을 필두로 지금까지 약 1,500만 부가 판매되었으며, 현재에도 독자들에게 변함없는 사랑을 받고 있다.\", \"creator\" : \"aladin\", \"isbn\" : \"K602934145\", \"isbn13\" : \"9791193790595\", \"itemId\" : 352558345, \"priceSales\" : 11700, \"priceStandard\" : 13000, \"stockStatus\" : \"\", \"mileage\" : 650, \"cover\":\"https:\\/\\/image.aladin.co.kr\\/product\\/35255\\/83\\/cover150\\/k602934145_1.jpg\", \"categoryId\" : 51120, \"categoryName\" : \"국내도서>소설/시/희곡>판타지/환상문학>외국판타지/환상소설\", \"publisher\":\"문학수첩\", \"customerReviewRank\":0  } ] };";
+
+        // when
+        when(bookCacheService.getCurrentPage(request)).thenReturn(currentResponse);
+        when(bookCacheService.cachingBookInfo(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(new GetBookInfoResponse("소설/시/희곡", "https://image.url", "해리 포터와 불의 잔 2 (양장)", "J.K. 롤링", "문학수첩", "2025-02-26", "9791193790694", "설명"));
+
+        GetBookListResponse response = bookService.searchBook(request, userId);
+
+        // then
+        assertThat(response.getBookList()).isNotNull();
+        assertThat(response.getBookList().size()).isEqualTo(10);
+        assertThat(response.getBookList().get(0).getBookTitle()).isEqualTo("해리 포터와 불의 잔 2 (양장)");
+
+        // verify
+        verify(recentSearchService, times(1)).addRecentSearch(userId, request.getSearchTerm());
+        verify(bookCacheService, times(2)).getCurrentPage(request); // 1번 동기적으로 호출(현재 페이지), 1번 비동기적으로 호출(다음 페이지)
+        verify(bookCacheService, times(10)).cachingBookInfo(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString());
+    }
+
+
+    @Test
+    @DisplayName("가장 인기 있는 책이 없을 때 null로 반환 테스트")
+    void test_showPopularBook_NotFound() {
+        // given
+        when(bookRepository.findBookWithMostRooms()).thenReturn(Collections.emptyList());
+
+        // when & then
+        assertThat(bookService.showPopularBook()).isNull();
+    }
+
+}

--- a/src/test/java/com/example/bookjourneybackend/domain/book/service/BookSearchTest.java
+++ b/src/test/java/com/example/bookjourneybackend/domain/book/service/BookSearchTest.java
@@ -54,7 +54,7 @@ class BookSearchTest {
 
     @Test
     @DisplayName("알라딘 api를 통해 책 검색을 했을 때 10개의 책이 반환되고, 캐싱이 올바르게 되고 있는지 테스트")
-    void test_searchBook() {
+    void searchBookByAladinApiWithCaching() {
         // given
         Long userId = 1L;
         GetBookListRequest request = GetBookListRequest.builder()
@@ -87,7 +87,7 @@ class BookSearchTest {
 
     @Test
     @DisplayName("가장 인기 있는 책이 없을 때 null로 반환 테스트")
-    void test_showPopularBook_NotFound() {
+    void returnNullIfNotExistPopularBook() {
         // given
         when(bookRepository.findBookWithMostRooms()).thenReturn(Collections.emptyList());
 

--- a/src/test/java/com/example/bookjourneybackend/domain/book/service/BookServiceTest.java
+++ b/src/test/java/com/example/bookjourneybackend/domain/book/service/BookServiceTest.java
@@ -100,7 +100,7 @@ class BookServiceTest {
 
     @Test
     @DisplayName("알라딘 api 호출이 제대로 되고 책 제목 검색이 제대로 되는지 테스트")
-    public void test_searchBook_byTitle() throws Exception {
+    public void searchBookByTitle() throws Exception {
         //given
         User user = userRepository.findByEmailAndStatus(email, ACTIVE).get();
         String searchTerm = "해리포터";
@@ -124,7 +124,7 @@ class BookServiceTest {
     @Test
     @Rollback(value = false)
     @DisplayName("알라딘 api 호출이 제대로 되고 작가 이름 검색이 제대로 되는지 테스트")
-    public void test_searchBook_byAuthor() throws Exception {
+    public void searchBookByAuthor() throws Exception {
         //given
         User user = userRepository.findByEmailAndStatus(email, ACTIVE).get();
         String searchTerm = "한강";
@@ -136,7 +136,6 @@ class BookServiceTest {
                 .build();
 
         //when
-
         GetBookListResponse response = bookService.searchBook(request, user.getUserId());
 
         //then
@@ -148,7 +147,7 @@ class BookServiceTest {
 
     @Test
     @DisplayName("요청한 isbn이 DB에 존재하지 않을 경우 알라딘 api를 호출하여 해당하는 책 정보를 반환하는지 테스트")
-    void test_showBookInfo_isNotExistDB() throws Exception {
+    void showBookInfoIfBookIsNotExistInDB() throws Exception {
         // given
         User user = userRepository.findByEmailAndStatus(email, ACTIVE).get();
         String isbn = "9791193790694";
@@ -162,7 +161,7 @@ class BookServiceTest {
     
     @Test
     @DisplayName("요청한 isbn이 DB에 존재하고 사용자가 이미 즐겨찾기해뒀을 경우 책 정보를 알맞게 반환하는지 테스트")
-    void test_showBookInfo_isExistDb() throws Exception {
+    void showBookInfoIfBookIsFavoriteBook() throws Exception {
         //given
         User user = userRepository.findByEmailAndStatus(email, ACTIVE).get();
         String isbn = "9791193790663";
@@ -197,7 +196,7 @@ class BookServiceTest {
 
     @Test
     @DisplayName("읽기횟수가 가장 많은 책을 알맞게 조회하는지 테스트")
-    public void test_showPopularBook() throws Exception {
+    public void showPopularBook() throws Exception {
         //given
         User user = userRepository.findByEmailAndStatus(email, ACTIVE).get();
 
@@ -245,7 +244,7 @@ class BookServiceTest {
 
     @Test
     @DisplayName("사용자의 관심장르에 따른 베스트셀러를 알맞게 조회하는지 테스트")
-    void test_showBestSeller() throws Exception {
+    void showBestSellerByUserFavoriteGenre() throws Exception {
         //given
         User user = userRepository.findByEmailAndStatus(email, ACTIVE).get();
         Book book = Book.builder()

--- a/src/test/java/com/example/bookjourneybackend/domain/book/service/BookServiceTest.java
+++ b/src/test/java/com/example/bookjourneybackend/domain/book/service/BookServiceTest.java
@@ -1,0 +1,278 @@
+package com.example.bookjourneybackend.domain.book.service;
+
+import com.example.bookjourneybackend.domain.book.domain.Book;
+import com.example.bookjourneybackend.domain.book.domain.repository.BookRepository;
+import com.example.bookjourneybackend.domain.book.dto.request.GetBookListRequest;
+import com.example.bookjourneybackend.domain.book.dto.response.GetBookBestSellersResponse;
+import com.example.bookjourneybackend.domain.book.dto.response.GetBookInfoResponse;
+import com.example.bookjourneybackend.domain.book.dto.response.GetBookListResponse;
+import com.example.bookjourneybackend.domain.book.dto.response.GetBookPopularResponse;
+import com.example.bookjourneybackend.domain.favorite.domain.Favorite;
+import com.example.bookjourneybackend.domain.favorite.domain.repository.FavoriteRepository;
+import com.example.bookjourneybackend.domain.recentSearch.service.RecentSearchService;
+import com.example.bookjourneybackend.domain.room.domain.Room;
+import com.example.bookjourneybackend.domain.room.domain.repository.RoomRepository;
+import com.example.bookjourneybackend.domain.user.domain.FavoriteGenre;
+import com.example.bookjourneybackend.domain.user.domain.User;
+import com.example.bookjourneybackend.domain.user.domain.repository.FavoriteGenreRepository;
+import com.example.bookjourneybackend.domain.user.domain.repository.UserRepository;
+import com.example.bookjourneybackend.domain.userRoom.domain.UserRoom;
+import com.example.bookjourneybackend.domain.userRoom.domain.repository.UserRoomRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static com.example.bookjourneybackend.domain.book.domain.GenreType.*;
+import static com.example.bookjourneybackend.domain.room.domain.RoomType.ALONE;
+import static com.example.bookjourneybackend.domain.userRoom.domain.UserRole.HOST;
+import static com.example.bookjourneybackend.global.entity.EntityStatus.ACTIVE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class BookServiceTest {
+
+    private final String email = "email@email.com";
+
+    @Autowired
+    private BookService bookService;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private FavoriteRepository favoriteRepository;
+
+    @Autowired
+    private BookCacheService bookCacheService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Autowired
+    private UserRoomRepository userRoomRepository;
+
+    @Autowired
+    private RecentSearchService recentSearchService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private FavoriteGenreRepository favoriteGenreRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @BeforeEach
+    void beforeEach() {
+        User user = User.builder()
+                .imageUrl("abcd.jpg")
+                .email(email)
+                .nickname("장현준")
+                .password("secretsecret123")
+                .build();
+
+        userRepository.save(user);
+        em.flush();
+        em.clear();
+    }
+
+    @AfterEach
+    void afterEach() {
+        userRepository.deleteAll();
+        bookRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("알라딘 api 호출이 제대로 되고 책 제목 검색이 제대로 되는지 테스트")
+    public void test_searchBook_byTitle() throws Exception {
+        //given
+        User user = userRepository.findByEmailAndStatus(email, ACTIVE).get();
+        String searchTerm = "해리포터";
+        GetBookListRequest getBookListRequest = GetBookListRequest.builder()
+                .searchTerm(searchTerm)
+                .genre(NOVEL_POETRY_DRAMA)
+                .queryType("Title")
+                .page(1)
+                .build();
+
+        //when
+        GetBookListResponse response = bookService.searchBook(getBookListRequest, user.getUserId());
+
+        //then
+        assertThat(response.getBookList().size()).isEqualTo(10);    //10개의 책이 잘 반환되었는지 확인
+        for (int i = 0; i < response.getBookList().size(); i++) {   //모든 검색어가 searchTerm으로 검색된 책인지 확인
+            assertThat(response.getBookList().get(i).getBookTitle().replace(" ","")).contains(searchTerm);
+        }
+    }
+
+    @Test
+    @Rollback(value = false)
+    @DisplayName("알라딘 api 호출이 제대로 되고 작가 이름 검색이 제대로 되는지 테스트")
+    public void test_searchBook_byAuthor() throws Exception {
+        //given
+        User user = userRepository.findByEmailAndStatus(email, ACTIVE).get();
+        String searchTerm = "한강";
+        GetBookListRequest request = GetBookListRequest.builder()
+                .searchTerm(searchTerm)
+                .genre(NOVEL_POETRY_DRAMA)
+                .queryType("Author")
+                .page(1)
+                .build();
+
+        //when
+
+        GetBookListResponse response = bookService.searchBook(request, user.getUserId());
+
+        //then
+        assertThat(response.getBookList().size()).isEqualTo(10);    //10개의 책이 잘 반환되었는지 확인
+        for (int i = 0; i < response.getBookList().size(); i++) {   //모든 검색어가 searchTerm으로 검색된 책인지 확인
+            assertThat(response.getBookList().get(i).getAuthorName().replace(" ","")).contains(searchTerm);
+        }
+    }
+
+    @Test
+    @DisplayName("요청한 isbn이 DB에 존재하지 않을 경우 알라딘 api를 호출하여 해당하는 책 정보를 반환하는지 테스트")
+    void test_showBookInfo_isNotExistDB() throws Exception {
+        // given
+        User user = userRepository.findByEmailAndStatus(email, ACTIVE).get();
+        String isbn = "9791193790694";
+
+        // when
+        GetBookInfoResponse response = bookService.showBookInfo(isbn, user.getUserId());
+
+        //then
+        assertThat(response.getIsbn()).isEqualTo(isbn);
+    }
+    
+    @Test
+    @DisplayName("요청한 isbn이 DB에 존재하고 사용자가 이미 즐겨찾기해뒀을 경우 책 정보를 알맞게 반환하는지 테스트")
+    void test_showBookInfo_isExistDb() throws Exception {
+        //given
+        User user = userRepository.findByEmailAndStatus(email, ACTIVE).get();
+        String isbn = "9791193790663";
+        Book book = Book.builder()
+                .bookTitle("해리 포터와 비밀의 방 (양장)")
+                .authorName("J.K. 롤링 지음, 강동혁 옮김")
+                .isbn(isbn)
+                .imageUrl("https://image.aladin.co.kr/product/35493/7/cover150/k562035555_1.jpg")
+                .genre(NOVEL_POETRY_DRAMA)
+                .publisher("문학수첩")
+                .build();
+
+        Favorite favorite = Favorite.builder()
+                .book(book)
+                .user(user)
+                .build();
+
+        //when
+        bookRepository.save(book);
+        favoriteRepository.save(favorite);
+        GetBookInfoResponse response = bookService.showBookInfo(isbn, user.getUserId());
+
+        //then
+        assertThat(response.getIsbn()).isEqualTo(isbn);
+        assertThat(response.isFavorite()).isTrue();
+        assertThat(response.getBookTitle()).isEqualTo(book.getBookTitle());
+        assertThat(response.getAuthorName()).isEqualTo(book.getAuthorName());
+        assertThat(response.getImageUrl()).isEqualTo(book.getImageUrl());
+        assertThat(response.getGenre()).isEqualTo(book.getGenre().getGenreType());
+        assertThat(response.getPublisher()).isEqualTo(book.getPublisher());
+    }
+
+    @Test
+    @DisplayName("읽기횟수가 가장 많은 책을 알맞게 조회하는지 테스트")
+    public void test_showPopularBook() throws Exception {
+        //given
+        User user = userRepository.findByEmailAndStatus(email, ACTIVE).get();
+
+        Book book = Book.builder()
+                .bookTitle("해리 포터와 불의 잔 2 (양장)")
+                .authorName("J.K. 롤링 지음, 강동혁 옮김")
+                .isbn("9791193790694")
+                .imageUrl("https://image.aladin.co.kr/product/35775/5/cover150/k232036847_1.jpg")
+                .genre(NOVEL_POETRY_DRAMA)
+                .publisher("문학수첩")
+                .pageCount(200)
+                .build();
+
+        Room room = Room.builder()
+                .roomName("room")
+                .isPublic(false)
+                .recruitCount(1)
+                .roomType(ALONE)
+                .roomPercentage(0.0)
+                .startDate(LocalDate.ofEpochDay(2025-02-13))
+                .book(book)
+                .build();
+
+        UserRoom userRoom = UserRoom.builder()
+                .room(room)
+                .user(user)
+                .userPercentage(0.0)
+                .userRole(HOST)
+                .currentPage(0)
+                .build();
+
+        //when
+        bookRepository.save(book);
+        roomRepository.save(room);
+        userRoomRepository.save(userRoom);
+        GetBookPopularResponse response = bookService.showPopularBook();
+
+        //then
+        assertThat(response.getBookTitle()).isEqualTo(book.getBookTitle());
+        assertThat(response.getAuthorName()).isEqualTo(book.getAuthorName());
+        assertThat(response.getImageUrl()).isEqualTo(book.getImageUrl());
+        assertThat(response.getDescription()).isEqualTo(book.getDescription());
+        assertThat(response.getIsbn()).isEqualTo(book.getIsbn());
+    }
+
+    @Test
+    @DisplayName("사용자의 관심장르에 따른 베스트셀러를 알맞게 조회하는지 테스트")
+    void test_showBestSeller() throws Exception {
+        //given
+        User user = userRepository.findByEmailAndStatus(email, ACTIVE).get();
+        Book book = Book.builder()
+                .bookTitle("해리 포터와 비밀의 방 (양장)")
+                .authorName("J.K. 롤링 지음, 강동혁 옮김")
+                .isbn("9791193790663")
+                .imageUrl("https://image.aladin.co.kr/product/35493/7/cover150/k562035555_1.jpg")
+                .genre(NOVEL_POETRY_DRAMA)
+                .publisher("문학수첩")
+                .bestSeller(true)
+                .build();
+
+        FavoriteGenre favoriteGenre = FavoriteGenre.builder()
+                .book(book)
+                .genre(NOVEL_POETRY_DRAMA)
+                .user(user)
+                .build();
+
+        //when
+        bookRepository.save(book);
+        favoriteGenreRepository.save(favoriteGenre);
+
+        GetBookBestSellersResponse response = bookService.showBestSellers(user.getUserId());
+
+        //then
+        assertThat(response.getBestSellerList().size()).isEqualTo(1);
+        assertThat(response.getBestSellerList().get(0).getImageUrl()).isEqualTo(book.getImageUrl());
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #187 

## 📝작업 내용

> Book 도메인의 service 로직에 대한 테스트코드를 작성하였습니다.

### 스크린샷 
BookService의 모든 메서드에 대한 테스트코드를 작성하였습니다.
<img width="371" alt="스크린샷 2025-02-16 오후 4 45 50" src="https://github.com/user-attachments/assets/246f4698-9cdb-479f-ae7a-6dcca9188317" />

추가적으로, BookService의 책 검색에 대하여 비동기적 호출과 캐싱에 대한 메서드가 적절하게 호출되고 있는지 테스트하고 읽기횟수가 많은 책 조회시 어떤 책도 존재하지 않으면 null을 반환하는지도 테스트하였습니다. 
<img width="379" alt="스크린샷 2025-02-16 오후 4 13 41" src="https://github.com/user-attachments/assets/d17395e4-d232-4f31-a674-eb61a61cdc0b" />



## 💬 추가 수정사항

> PR과 별개로 로깅 시스템의 로그 출력 문자열을 직관적으로 수정하고 응답 소요시간을 출력하도록 하였습니다!
<img width="822" alt="스크린샷 2025-02-16 오후 5 02 13" src="https://github.com/user-attachments/assets/0ad89618-d8f2-4455-ad7d-78e4393726e5" />
<img width="959" alt="스크린샷 2025-02-16 오후 5 02 23" src="https://github.com/user-attachments/assets/ef14a940-3921-49c0-862a-d860e69448fa" />

### 그외 고민..
현재 BookSearchTest에서 Mock으로 알라딘 api의 응답을 currentResponse로 지정하고 그에 따른 로직을 확인하기 때문에 불가피하게 아~~~주 긴 currentResponse를 하드코딩하여 사용하는데 보기가 조금 그래서...다른 방법이 있을까욥

