### PR TITLE
[BUG] 책 찾기 api에서 각 책에 대한 정보를 캐싱할 때 장르 파싱 오류 수정

### DIFF
--- a/src/main/java/com/example/bookjourneybackend/domain/book/domain/Book.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/domain/Book.java
@@ -7,7 +7,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,10 +26,9 @@ public class Book extends BaseEntity {
     @Column(nullable = false)
     private GenreType genre;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 500)
     private String bookTitle;
 
-    @Column(length = 255)
     private String publisher;
 
     private LocalDate publishedDate;
@@ -41,10 +39,10 @@ public class Book extends BaseEntity {
     @Setter
     private Integer pageCount;
 
-    @Column(length = 1000)
+    @Column(length = 3000)
     private String description;
 
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false)
     private String authorName;
 
     @Builder.Default
@@ -55,7 +53,7 @@ public class Book extends BaseEntity {
     @OneToMany(mappedBy = "book", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Room> rooms = new ArrayList<>();
 
-    @Column(nullable = false, length = 500)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String imageUrl;
 
     @Setter

--- a/src/main/java/com/example/bookjourneybackend/domain/book/domain/Book.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/domain/Book.java
@@ -44,7 +44,7 @@ public class Book extends BaseEntity {
     @Column(length = 1000)
     private String description;
 
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false)
     private String authorName;
 
     @Builder.Default
@@ -55,7 +55,7 @@ public class Book extends BaseEntity {
     @OneToMany(mappedBy = "book", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Room> rooms = new ArrayList<>();
 
-    @Column(nullable = false, length = 500)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String imageUrl;
 
     @Setter

--- a/src/main/java/com/example/bookjourneybackend/domain/book/domain/Book.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/book/domain/Book.java
@@ -44,7 +44,7 @@ public class Book extends BaseEntity {
     @Column(length = 1000)
     private String description;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 50)
     private String authorName;
 
     @Builder.Default
@@ -55,7 +55,7 @@ public class Book extends BaseEntity {
     @OneToMany(mappedBy = "book", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Room> rooms = new ArrayList<>();
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, length = 500)
     private String imageUrl;
 
     @Setter

--- a/src/main/java/com/example/bookjourneybackend/domain/comment/domain/Comment.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/comment/domain/Comment.java
@@ -30,7 +30,7 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(nullable = false, length = 3000)
+    @Column(nullable = false)
     private String content;
 
     @Builder.Default

--- a/src/main/java/com/example/bookjourneybackend/domain/comment/domain/Comment.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/comment/domain/Comment.java
@@ -30,7 +30,7 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(nullable = false, length = 3000)
+    @Column(nullable = false, length = 10000)
     private String content;
 
     @Builder.Default

--- a/src/main/java/com/example/bookjourneybackend/domain/comment/domain/Comment.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/comment/domain/Comment.java
@@ -30,7 +30,7 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 3000)
     private String content;
 
     @Builder.Default

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/RecentSearch.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/RecentSearch.java
@@ -24,7 +24,7 @@ public class RecentSearch extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "recent_search", nullable = false, length = 255)
+    @Column(name = "recent_search", nullable = false)
     private String recentSearch;
 
     @Builder

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/RecentSearch.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/RecentSearch.java
@@ -24,7 +24,7 @@ public class RecentSearch extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "recent_search", nullable = false, length = 255)
+    @Column(name = "recent_search", nullable = false, length = 45)
     private String recentSearch;
 
     @Builder

--- a/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/RecentSearch.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/recentSearch/domain/RecentSearch.java
@@ -24,7 +24,7 @@ public class RecentSearch extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "recent_search", nullable = false)
+    @Column(name = "recent_search", nullable = false, length = 255)
     private String recentSearch;
 
     @Builder

--- a/src/main/java/com/example/bookjourneybackend/domain/record/domain/Record.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/domain/Record.java
@@ -31,7 +31,6 @@ public class Record extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(length = 90)
     private String recordTitle;
 
     @Enumerated(EnumType.STRING)
@@ -40,7 +39,7 @@ public class Record extends BaseEntity {
 
     private Integer recordPage;
 
-    @Column(nullable = false, length = 3000)
+    @Column(nullable = false)
     private String content;
 
     @Builder.Default

--- a/src/main/java/com/example/bookjourneybackend/domain/record/domain/Record.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/domain/Record.java
@@ -40,7 +40,7 @@ public class Record extends BaseEntity {
 
     private Integer recordPage;
 
-    @Column(nullable = false, length = 3000)
+    @Column(nullable = false, length = 10000)
     private String content;
 
     @Builder.Default

--- a/src/main/java/com/example/bookjourneybackend/domain/record/domain/Record.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/record/domain/Record.java
@@ -31,6 +31,7 @@ public class Record extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Column(length = 90)
     private String recordTitle;
 
     @Enumerated(EnumType.STRING)
@@ -39,7 +40,7 @@ public class Record extends BaseEntity {
 
     private Integer recordPage;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 3000)
     private String content;
 
     @Builder.Default

--- a/src/main/java/com/example/bookjourneybackend/domain/room/domain/Room.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/room/domain/Room.java
@@ -29,7 +29,7 @@ public class Room extends BaseEntity {
     @Column(nullable = false)
     private RoomType roomType;
 
-    @Column(length = 60)
+    @Column(length = 75)
     private String roomName;
 
     @Setter

--- a/src/main/java/com/example/bookjourneybackend/domain/user/domain/User.java
+++ b/src/main/java/com/example/bookjourneybackend/domain/user/domain/User.java
@@ -26,11 +26,11 @@ public class User extends BaseEntity{
     @Column(name = "user_id")
     private Long userId;
 
-    @Column(name = "email", nullable = false, length = 255)
+    @Column(name = "email", nullable = false)
     private String email;
 
     @Setter
-    @Column(name = "password", nullable = false, length = 255)
+    @Column(name = "password", nullable = false, length = 20)
     private String password;
 
     @Setter


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #190 

## 📝작업 내용

> 책 찾기 api에서 각 책에 대한 정보를 파싱할때 장르 매핑이 안되어서 '알 수 없는 장르'로 뜨는 오류를 해결하였습니다. 추가적으로, 알라딘 api에서 isbn이 'K'로 넘어오는 책들은 보통 책이 아닌 굿즈인 경우가 많아서 필터링해서 제외시켰습니다. 

### 스크린샷 (선택)
<img width="847" alt="스크린샷 2025-02-17 오후 8 00 33" src="https://github.com/user-attachments/assets/c2edbc52-3ee1-4da4-9933-9260ef8e944d" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
